### PR TITLE
setting engine_version type to map(string)

### DIFF
--- a/tf-modules/aws/rds/vars.tf
+++ b/tf-modules/aws/rds/vars.tf
@@ -114,7 +114,7 @@ variable "engine" {
 
 variable "engine_version" {
   description = "Engine version"
-
+  type        = map(string)
   default = {
     mysql    = "5.6.41"
     postgres = "9.6.8"


### PR DESCRIPTION
The type needs to be set here to be able to properly override the variable from terragrunt or a TF_VAR envvar.