### PR TITLE
Cleaning up variables.tf file for eks module

### DIFF
--- a/terraform-modules/aws/eks/variables.tf
+++ b/terraform-modules/aws/eks/variables.tf
@@ -1,7 +1,9 @@
 variable "aws_region" {
   default = "us-east-1"
 }
-variable "tags" {}
+variable "tags" {
+  type = map(any)
+}
 variable "vpc_id" {
   default = ""
 }
@@ -15,8 +17,8 @@ variable "public_subnets" {
 }
 
 variable "k8s_subnets" {
-  type = list(any)
-  default = []
+  type        = list(any)
+  default     = []
   description = "Subnet IDs to place the EKS nodes into"
 }
 
@@ -116,12 +118,12 @@ variable "cluster_log_retention_in_days" {
 variable "cluster_endpoint_private_access" {
   type        = bool
   default     = false
-  description = "Enable or disable Kube API private access"   
+  description = "Enable or disable Kube API private access"
 }
 
 variable "cluster_endpoint_private_access_cidrs" {
-  type = list(string)
-  default = null
+  type        = list(string)
+  default     = null
   description = "Kube API public endpoint allow access cidrs"
 }
 


### PR DESCRIPTION
Variables of non-string types can cause issues with tools like terragrunt (e.g. https://github.com/gruntwork-io/terragrunt/issues/1007) if the type is not explicitly defined when the variable is declared in the module.

This pull request adds a type to the `tags` variable in the eks module, making it consistent with the vpc, istio, and other modules in this repo.