### PR TITLE
output vars for route table ids public and privates subnets and name of vpc

### DIFF
--- a/terraform-modules/aws/vpc/outputs.tf
+++ b/terraform-modules/aws/vpc/outputs.tf
@@ -24,11 +24,11 @@ output "k8s_subnets" {
 }
 
 output "private_route_table_ids" {
-  description = "A list of private k8s subnets"
+  description = "A list of route table ids for private subnets"
   value       = module.vpc.private_route_table_ids
 }
 
 output "public_route_table_ids" {
-  description = "A list of private k8s subnets"
+  description = "A list of route table ids for public subnets"
   value       = module.vpc.public_route_table_ids
 }

--- a/terraform-modules/aws/vpc/outputs.tf
+++ b/terraform-modules/aws/vpc/outputs.tf
@@ -22,3 +22,13 @@ output "k8s_subnets" {
   description = "A list of private k8s subnets"
   value       = module.vpc.elasticache_subnets
 }
+
+output "private_route_table_ids" {
+  description = "A list of private k8s subnets"
+  value       = module.vpc.private_route_table_ids
+}
+
+output "public_route_table_ids" {
+  description = "A list of private k8s subnets"
+  value       = module.vpc.public_route_table_ids
+}

--- a/terraform-modules/aws/vpc/outputs.tf
+++ b/terraform-modules/aws/vpc/outputs.tf
@@ -3,6 +3,11 @@ output "vpc_id" {
   value       = module.vpc.vpc_id
 }
 
+output "vpc_name" {
+  description = "name of vpc"
+  value       = module.vpc.name
+}
+
 output "vpc_cidr_block" {
   description = "The CIDR block of the VPC"
   value       = var.vpc_cidr
@@ -32,3 +37,4 @@ output "public_route_table_ids" {
   description = "A list of route table ids for public subnets"
   value       = module.vpc.public_route_table_ids
 }
+


### PR DESCRIPTION
### What does it do this?
- Obtains a list of routing table ids on public subnets and another for private subnets.
- Name of vpc 

**_Necessity_**: 
It is necessary to perform peerings between vpcs and get the auto-generated route table ids.

_**Reference documentation**_
[private_route_table_ids](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/2.77.0?tab=outputs#:~:text=private_route_table_ids
)
[public_route_table_ids](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/2.77.0?tab=outputs#:~:text=public_route_table_ids)
[name of vpc](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/2.77.0?tab=outputs#:~:text=IPv6%20enabled%20VPC-,name,-Description%3A%20The%20name)
