### PR TITLE
add secondary cidr_blocks as output var in vpc mod

### DIFF
--- a/terraform-modules/aws/vpc/outputs.tf
+++ b/terraform-modules/aws/vpc/outputs.tf
@@ -38,3 +38,7 @@ output "public_route_table_ids" {
   value       = module.vpc.public_route_table_ids
 }
 
+output "vpc_secondary_cidr_blocks" {
+  description = "List of secondary CIDR blocks of the VPC"
+  value       = module.vpc.vpc_secondary_cidr_blocks
+}


### PR DESCRIPTION
### What does it do this?
- Obtains a list of secondary CIDRs of vpc  
_**Reference documentation**_
[vpc_secondary_cidr_blocks](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest?tab=outputs#:~:text=vpc_secondary_cidr_blocks
)