### PR TITLE
Exposing IAM Role ARNs as outputs of the EKS module

### DIFF
--- a/terraform-modules/aws/eks/outputs.tf
+++ b/terraform-modules/aws/eks/outputs.tf
@@ -31,6 +31,14 @@ output "worker_security_group_id" {
   value = module.eks.worker_security_group_id
 }
 
+output "cluster_iam_role_arn" {
+  value = module.eks.cluster_iam_role_arn
+}
+
+output "worker_iam_role_arn" {
+  value = module.eks.worker_iam_role_arn
+}
+
 output "cluster_arn" {
   value = module.eks.cluster_arn
 }


### PR DESCRIPTION
The ARN of the worker IAM role created by this module is needed, for example, when [setting up a user for Mongo Atlas](https://github.com/ManagedKube/kubernetes-ops/pull/249).