### PR TITLE
Certificate on-demand in istio-gateway and new input params gateway hosts and credentialName

### DIFF
--- a/terraform-modules/aws/istio-networking/main-gateway/gateway.tpl.yaml
+++ b/terraform-modules/aws/istio-networking/main-gateway/gateway.tpl.yaml
@@ -13,14 +13,16 @@ spec:
       number: 80
       name: http
       protocol: HTTP
-    hosts:
-    - "*"
+    hosts: 
+      %{ for host in gateway_hosts ~}
+      - ${host}
+      %{ endfor ~}
   - port:
       number: 443
       name: https
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: domain-wildcard # This should match the Certificate secretName
+      credentialName: ${gateway_credentialName} # This should match the Certificate secretName
     hosts:
     - "*" # This should match a DNS name in the Certificate

--- a/terraform-modules/aws/istio-networking/main-gateway/gateway.tpl.yaml
+++ b/terraform-modules/aws/istio-networking/main-gateway/gateway.tpl.yaml
@@ -13,10 +13,7 @@ spec:
       number: 80
       name: http
       protocol: HTTP
-    hosts: 
-      %{ for host in gateway_hosts ~}
-      - ${host}
-      %{ endfor ~}
+    host: ${gateway_hosts}
   - port:
       number: 443
       name: https

--- a/terraform-modules/aws/istio-networking/main-gateway/main.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/main.tf
@@ -24,6 +24,7 @@ resource "kubectl_manifest" "gateway" {
 
 # file templating
 data "template_file" "certificate" {
+  count     = ${var.enable_certificate 1 : 0}
   template = file("${path.module}/certificate.tpl.yaml")
 
   vars = {
@@ -38,5 +39,6 @@ data "template_file" "certificate" {
 }
 
 resource "kubectl_manifest" "certificate" {
-  yaml_body = data.template_file.certificate.rendered
+  count     = ${var.enable_certificate 1 : 0}
+  yaml_body = data.template_file.certificate[0].rendered
 }

--- a/terraform-modules/aws/istio-networking/main-gateway/main.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/main.tf
@@ -15,6 +15,8 @@ data "template_file" "gateway" {
 
   vars = {
     namespace  = var.namespace
+    gateway_hosts = var.gateway_hosts
+    gateway_credentialName = var.gateway_credentialName
   }
 }
 

--- a/terraform-modules/aws/istio-networking/main-gateway/main.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/main.tf
@@ -15,7 +15,7 @@ data "template_file" "gateway" {
 
   vars = {
     namespace  = var.namespace
-    gateway_hosts = var.gateway_hosts
+    gateway_hosts =  "${jsonencode(var.gateway_hosts)}"
     gateway_credentialName = var.gateway_credentialName
   }
 }

--- a/terraform-modules/aws/istio-networking/main-gateway/main.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/main.tf
@@ -26,7 +26,7 @@ resource "kubectl_manifest" "gateway" {
 
 # file templating
 data "template_file" "certificate" {
-  count     = ${var.enable_certificate 1 : 0}
+  count    = var.enable_certificate ? 1 : 0
   template = file("${path.module}/certificate.tpl.yaml")
 
   vars = {
@@ -41,6 +41,6 @@ data "template_file" "certificate" {
 }
 
 resource "kubectl_manifest" "certificate" {
-  count     = ${var.enable_certificate 1 : 0}
+  count     = var.enable_certificate ? 1 : 0
   yaml_body = data.template_file.certificate[0].rendered
 }

--- a/terraform-modules/aws/istio-networking/main-gateway/variables.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/variables.tf
@@ -32,6 +32,7 @@ variable "cert_dns_name" {
 variable "enable_certificate" {
   type = bool
   description = "If set to true, it will create the certificate resource on-demand"
+  default = true
 }
 
 variable "issue_ref_name" {

--- a/terraform-modules/aws/istio-networking/main-gateway/variables.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/variables.tf
@@ -46,3 +46,15 @@ variable "issue_ref_kind" {
 variable "issue_ref_group" {
   default = "cert-manager.io"
 }
+
+variable "gateway_hosts" {
+  type    = list(string)
+  description = "the list of hosts available for the gateway"
+  default = ["*"]
+}
+
+variable "gateway_credentialName" {
+  type    = string
+  description = "This is the gateway matches the secretName field in the certificate"
+  default = "domain-wildcard" 
+}

--- a/terraform-modules/aws/istio-networking/main-gateway/variables.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/variables.tf
@@ -31,7 +31,7 @@ variable "cert_dns_name" {
 
 variable "enable_certificate" {
   type = bool
-  description = "Create certificate resource on-demand"
+  description = "If set to true, it will create certificate resource on-demand"
 }
 
 variable "issue_ref_name" {

--- a/terraform-modules/aws/istio-networking/main-gateway/variables.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/variables.tf
@@ -28,7 +28,12 @@ variable "cert_dns_name" {
   type = string
   description = "The dns name for the certificate"
 }
-  
+
+variable "enable_certificate" {
+  type = bool
+  description = "Create certificate resource on-demand"
+}
+
 variable "issue_ref_name" {
   default = "letsencrypt-prod-dns01"
 }

--- a/terraform-modules/aws/istio-networking/main-gateway/variables.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/variables.tf
@@ -31,7 +31,7 @@ variable "cert_dns_name" {
 
 variable "enable_certificate" {
   type = bool
-  description = "If set to true, it will create certificate resource on-demand"
+  description = "If set to true, it will create the certificate resource on-demand"
 }
 
 variable "issue_ref_name" {


### PR DESCRIPTION
This component is enabled to:

1. Create the certificate on demand through the variable: [enable_certificate](https://github.com/ManagedKube/kubernetes-ops/blob/472841123906bae9f6c2d8c67938566993460d9e/terraform-modules/aws/istio-networking/main-gateway/variables.tf#L32). 
2. New input parameter [gateway_hosts](https://github.com/ManagedKube/kubernetes-ops/pull/255/files#:~:text=host%3A%20%24%7Bgateway_hosts%7D)
3. New input parameter [gateway_credentialName](https://github.com/ManagedKube/kubernetes-ops/pull/255/files#:~:text=credentialName%3A%20%24%7Bgateway_credentialName%7D)   


A plan was made locally, reflecting the resulting yaml files.
Input vars:
```
variable "gateway_hosts" {
  type    = list(string)
  description = "the list of hosts available for the gateway"
  default = ["host1","host2","host3"]
}

variable "gateway_credentialName" {
  type    = string
  description = "This is the gateway matches the secretName field in the certificate"
  default = "domain-wildcard" 
}
```
Result:
```
➜  main-gateway git:(feature/main-gateway-certificate-on-demand) ✗ terraform plan
var.cert_common_name
  The common name for the certificate

  Enter a value: commonname_value

var.cert_dns_name
  The dns name for the certificate

  Enter a value: dns_value

var.cluster_ca_certificate
  The eks kubernetes cluster_ca_certificate

  Enter a value: cluster_ca_certificate_value

var.cluster_name
  The name of the EKS cluster

  Enter a value: cluster_name_value 

var.kubernetes_api_host
  The eks kubernetes api host endpoint

  Enter a value: kubernetes_api_host_value


Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create

Terraform will perform the following actions:

  # kubectl_manifest.certificate[0] will be created
  + resource "kubectl_manifest" "certificate" {
      + api_version             = "cert-manager.io/v1"
      + force_new               = false
      + id                      = (known after apply)
      + kind                    = "Certificate"
      + live_manifest_incluster = (sensitive value)
      + live_uid                = (known after apply)
      + name                    = "domain-wildcard"
      + namespace               = "istio-system"
      + server_side_apply       = false
      + uid                     = (known after apply)
      + validate_schema         = true
      + wait_for_rollout        = true
      + yaml_body               = (sensitive value)
      + yaml_body_parsed        = <<-EOT
            apiVersion: cert-manager.io/v1
            kind: Certificate
            metadata:
              name: domain-wildcard
              namespace: istio-system
            spec:
              commonName: commonname_value
              dnsNames:
              - dns_value
              issuerRef:
                group: cert-manager.io
                kind: ClusterIssuer
                name: letsencrypt-prod-dns01
              secretName: domain-wildcard
        EOT
      + yaml_incluster          = (sensitive value)
    }

  # kubectl_manifest.gateway will be created
  + resource "kubectl_manifest" "gateway" {
      + api_version             = "networking.istio.io/v1alpha3"
      + force_new               = false
      + id                      = (known after apply)
      + kind                    = "Gateway"
      + live_manifest_incluster = (sensitive value)
      + live_uid                = (known after apply)
      + name                    = "main-gateway"
      + namespace               = "istio-system"
      + server_side_apply       = false
      + uid                     = (known after apply)
      + validate_schema         = true
      + wait_for_rollout        = true
      + yaml_body               = (sensitive value)
      + yaml_body_parsed        = <<-EOT
            apiVersion: networking.istio.io/v1alpha3
            kind: Gateway
            metadata:
              name: main-gateway
              namespace: istio-system
            spec:
              selector:
                app: istio-ingressgateway
                istio: ingressgateway
              servers:
              - host:
                - host1
                - host2
                - host3
                port:
                  name: http
                  number: 80
                  protocol: HTTP
              - hosts:
                - '*'
                port:
                  name: https
                  number: 443
                  protocol: HTTPS
                tls:
                  credentialName: domain-wildcard
                  mode: SIMPLE
        EOT
      + yaml_incluster          = (sensitive value)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```
You can see the values correctly idented in: 
[Click here to highlight : gateway_host](https://github.com/ManagedKube/kubernetes-ops/pull/255#:~:text=%2D%20host%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2D%20host1%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2D%20host2%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2D%20host3)
[Click here to highlight: credentialName](https://github.com/ManagedKube/kubernetes-ops/pull/255#:~:text=credentialName%3A%20domain%2Dwildcard)