### PR TITLE
provider gavinbunney for kubectl

### DIFF
--- a/terraform-modules/aws/istio-networking/main-gateway/main.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
+  }
+}
+
 data "aws_eks_cluster_auth" "main" {
   name = var.cluster_name
 }


### PR DESCRIPTION
The istio-main-gateway requires a provider to works in kubectl resource.
```
terraform {
  required_providers {
    kubectl = {
      source  = "gavinbunney/kubectl"
      version = ">= 1.7.0"
    }
  }
}
```
b/c when this resource is using in one user, we have this error: 

```

│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider
│ hashicorp/kubectl: provider registry registry.terraform.io does not have a
│ provider named registry.terraform.io/hashicorp/kubectl
│ 
│ All modules should specify their required_providers so that external
│ consumers will get the correct providers when using a module. To see which
│ modules are currently depending on hashicorp/kubectl, run the following
│ command:
│     terraform providers
```
