### PR TITLE
Default values cert_common_name and cert_dns_name

### DIFF
--- a/terraform-modules/aws/istio-networking/main-gateway/variables.tf
+++ b/terraform-modules/aws/istio-networking/main-gateway/variables.tf
@@ -22,11 +22,13 @@ variable "namespace" {
 variable "cert_common_name" {
   type = string
   description = "The common name for the certificate"
+  default = ""
 }
 
 variable "cert_dns_name" {
   type = string
   description = "The dns name for the certificate"
+  default = ""
 }
 
 variable "enable_certificate" {


### PR DESCRIPTION
In order to turn off the use of the certificate, it is necessary to define this vars the cert_common_name variables and
cert_dns_name as no required values for avoiding assignments empty on users side. 

```
╷
│ Error: No value for required variable
│ 
│   on variables.tf line 22:
│   22: variable "cert_common_name" {
│ 
│ The root module input variable "cert_common_name" is not set, and has no
│ default value. Use a -var or -var-file command line argument to provide a
│ value for this variable.
╵
╷
│ Error: No value for required variable
│ 
│   on variables.tf line 27:
│   27: variable "cert_dns_name" {
│ 
│ The root module input variable "cert_dns_name" is not set, and has no
│ default value. Use a -var or -var-file command line argument to provide a
│ value for this variable.
╵
```