### PR TITLE
sintaxs error: replace host with hosts

### DIFF
--- a/terraform-modules/aws/istio-networking/main-gateway/gateway.tpl.yaml
+++ b/terraform-modules/aws/istio-networking/main-gateway/gateway.tpl.yaml
@@ -13,7 +13,7 @@ spec:
       number: 80
       name: http
       protocol: HTTP
-    host: ${gateway_hosts}
+    hosts: ${gateway_hosts}
   - port:
       number: 443
       name: https


### PR DESCRIPTION
Bugfix 
Syntax error in module main-gateway, replace host with hosts.