### PR TITLE
New input var account_id

### DIFF
--- a/terraform-modules/aws/helm/external-secrets/install/helm_values.tpl.yaml
+++ b/terraform-modules/aws/helm/external-secrets/install/helm_values.tpl.yaml
@@ -1,8 +1,8 @@
 ---
-extraEnv:
-- name: AWS_REGION
+env:
+  name: AWS_REGION
   value: ${awsRegion}
-- name: AWS_DEFAULT_REGION
+  name: AWS_DEFAULT_REGION
   value: ${awsRegion}
 
 serviceAccount:

--- a/terraform-modules/aws/helm/external-secrets/install/helm_values.tpl.yaml
+++ b/terraform-modules/aws/helm/external-secrets/install/helm_values.tpl.yaml
@@ -1,8 +1,8 @@
 ---
-env:
-  name: AWS_REGION
+extraEnv:
+- name: AWS_REGION
   value: ${awsRegion}
-  name: AWS_DEFAULT_REGION
+- name: AWS_DEFAULT_REGION
   value: ${awsRegion}
 
 serviceAccount:

--- a/terraform-modules/aws/helm/external-secrets/install/main.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/main.tf
@@ -21,7 +21,7 @@ module "iam_assumable_role_admin" {
 data "template_file" "iam_policy" {
   template = file("${path.module}/iam-policy.tpl.json")
   vars = {
-    awsAccountID  = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id
+    awsAccountID  = var.account_id != "" ? var.account_id : data.aws_caller_identity.current.account_id
     awsRegion     = data.aws_region.current.name
     secretsPrefix = var.secrets_prefix
     envName       = var.environment_name
@@ -41,7 +41,7 @@ resource "aws_iam_policy" "cluster_autoscaler" {
 data "template_file" "helm_values" {
   template = file("${path.module}/helm_values.tpl.yaml")
   vars = {
-    awsAccountID       = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id
+    awsAccountID       = var.account_id != "" ? var.account_id : data.aws_caller_identity.current.account_id
     awsRegion          = data.aws_region.current.name
     #serviceAccountName = local.k8s_service_account_name
     resource_name      = "${local.base_name}-${var.environment_name}"

--- a/terraform-modules/aws/helm/external-secrets/install/main.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/main.tf
@@ -43,7 +43,7 @@ data "template_file" "helm_values" {
   vars = {
     awsAccountID       = data.aws_caller_identity.current.account_id
     awsRegion          = data.aws_region.current.name
-    # serviceAccountName = local.k8s_service_account_name
+    serviceAccountName = local.k8s_service_account_name
     resource_name      = "${local.base_name}-${var.environment_name}"
   }
 }

--- a/terraform-modules/aws/helm/external-secrets/install/main.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/main.tf
@@ -43,7 +43,7 @@ data "template_file" "helm_values" {
   vars = {
     awsAccountID       = data.aws_caller_identity.current.account_id
     awsRegion          = data.aws_region.current.name
-    serviceAccountName = local.k8s_service_account_name
+    #serviceAccountName = local.k8s_service_account_name
     resource_name      = "${local.base_name}-${var.environment_name}"
   }
 }

--- a/terraform-modules/aws/helm/external-secrets/install/main.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/main.tf
@@ -21,7 +21,7 @@ module "iam_assumable_role_admin" {
 data "template_file" "iam_policy" {
   template = file("${path.module}/iam-policy.tpl.json")
   vars = {
-    awsAccountID  = data.aws_caller_identity.current.account_id
+    awsAccountID  = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id
     awsRegion     = data.aws_region.current.name
     secretsPrefix = var.secrets_prefix
     envName       = var.environment_name
@@ -41,7 +41,7 @@ resource "aws_iam_policy" "cluster_autoscaler" {
 data "template_file" "helm_values" {
   template = file("${path.module}/helm_values.tpl.yaml")
   vars = {
-    awsAccountID       = data.aws_caller_identity.current.account_id
+    awsAccountID       = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id
     awsRegion          = data.aws_region.current.name
     #serviceAccountName = local.k8s_service_account_name
     resource_name      = "${local.base_name}-${var.environment_name}"

--- a/terraform-modules/aws/helm/external-secrets/install/main.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/main.tf
@@ -21,7 +21,7 @@ module "iam_assumable_role_admin" {
 data "template_file" "iam_policy" {
   template = file("${path.module}/iam-policy.tpl.json")
   vars = {
-    awsAccountID  = var.account_id != "" ? var.account_id : data.aws_caller_identity.current.account_id
+    awsAccountID  = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id
     awsRegion     = data.aws_region.current.name
     secretsPrefix = var.secrets_prefix
     envName       = var.environment_name
@@ -41,7 +41,7 @@ resource "aws_iam_policy" "cluster_autoscaler" {
 data "template_file" "helm_values" {
   template = file("${path.module}/helm_values.tpl.yaml")
   vars = {
-    awsAccountID       = var.account_id != "" ? var.account_id : data.aws_caller_identity.current.account_id
+    awsAccountID       = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id
     awsRegion          = data.aws_region.current.name
     #serviceAccountName = local.k8s_service_account_name
     resource_name      = "${local.base_name}-${var.environment_name}"

--- a/terraform-modules/aws/helm/external-secrets/install/variables.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/variables.tf
@@ -54,6 +54,6 @@ variable "secrets_prefix" {
 
 variable "account_id" {
   type        = string
-  default     = null
+  default     = ""
   description = "The account_id of your AWS Account. This allows sure the use of the account number in the role to mitigate issue of aws_caller_id showing *** by obtaining the value of account_id "
 }

--- a/terraform-modules/aws/helm/external-secrets/install/variables.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/variables.tf
@@ -51,3 +51,9 @@ variable "secrets_prefix" {
   default     = ""
   description = "The prefix to your AWS Secrets.  This allows this module to craft a more tightly controlled set of IAM policies to only allow it to get certain secrets"
 }
+
+variable "account_id" {
+  type        = string
+  default     = ""
+  description = "The account_id of your AWS Account. This allows sure the use of the account number in the role to mitigate issue of aws_caller_id showing *** by obtaining the value of account_id "
+}

--- a/terraform-modules/aws/helm/external-secrets/install/variables.tf
+++ b/terraform-modules/aws/helm/external-secrets/install/variables.tf
@@ -54,6 +54,6 @@ variable "secrets_prefix" {
 
 variable "account_id" {
   type        = string
-  default     = ""
+  default     = null
   description = "The account_id of your AWS Account. This allows sure the use of the account number in the role to mitigate issue of aws_caller_id showing *** by obtaining the value of account_id "
 }


### PR DESCRIPTION
### **_What does this do?_**
Implements a new input variable called `account_id` in order to mitigate an issue found in aws_caller_id, which instead of getting the aws `account number` like: `54518548741` of the currently calling process, it's getting `***`

**_Testing:_**
- When the user does not pass the account_id variable, the aws_caller_id is executed.
`awsAccountID  = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id`
![Screen Shot 2022-03-09 at 10 22 53](https://user-images.githubusercontent.com/19688747/157484533-ef4810af-9d66-4142-9964-03cbd8884370.png)

- When the user pass a value in account_id variable
`awsAccountID  = var.account_id != null ? var.account_id : data.aws_caller_identity.current.account_id`
![Screen Shot 2022-03-09 at 10 47 09](https://user-images.githubusercontent.com/19688747/157489490-6a60dd2d-ac93-4044-936d-f8bc701afb64.png)

