### PR TITLE
Enable percent encoding password

### DIFF
--- a/terraform-modules/aws/mongodb-atlas-user-list/main.tf
+++ b/terraform-modules/aws/mongodb-atlas-user-list/main.tf
@@ -11,7 +11,7 @@ terraform {
 resource "mongodbatlas_database_user" "this" {
   count              = length(var.database_users)
   username           = var.database_users[count.index].username
-  password           = var.enable_aws_secret ? aws_secretsmanager_secret_version.this[count.index].secret_string : var.database_users[count.index].user_password
+  password           = var.enable_aws_secret ? random_password.password[count.index].result : var.database_users[count.index].user_password
   project_id         = var.mongodbatlas_projectid
   auth_database_name = var.database_users[count.index].auth_database_name
 

--- a/terraform-modules/aws/mongodb-atlas-user-list/main.tf
+++ b/terraform-modules/aws/mongodb-atlas-user-list/main.tf
@@ -52,5 +52,5 @@ resource "random_password" "password" {
 resource "aws_secretsmanager_secret_version" "this" {
   count         = var.enable_aws_secret ? length(var.database_users) : 0
   secret_id     = aws_secretsmanager_secret.this[count.index].id
-  secret_string = random_password.password[count.index].result
+  secret_string = var.enable_percent_encoding_password ? urlencode(random_password.password[count.index].result) : random_password.password[count.index].result
 }

--- a/terraform-modules/aws/mongodb-atlas-user-list/variables.tf
+++ b/terraform-modules/aws/mongodb-atlas-user-list/variables.tf
@@ -28,7 +28,7 @@ variable "enable_aws_secret" {
 variable "enable_percent_encoding_password" {
   type        = bool
   default     = false
-  description = "A flag to denote that we will put the password secret into aws secret in percent encoding accourding mongodb documentation: https://www.mongodb.com/docs/manual/reference/connection-string/#examples"
+  description = "A flag to denote that we will put the password secret into aws secret in percent encoding according mongodb documentation: https://www.mongodb.com/docs/manual/reference/connection-string/#examples"
 }
 
 variable "database_users" {

--- a/terraform-modules/aws/mongodb-atlas-user-list/variables.tf
+++ b/terraform-modules/aws/mongodb-atlas-user-list/variables.tf
@@ -25,6 +25,12 @@ variable "enable_aws_secret" {
   description = "A flag to denote that we will put the password secret into aws secret"
 }
 
+variable "enable_percent_encoding_password" {
+  type        = bool
+  default     = false
+  description = "A flag to denote that we will put the password secret into aws secret in percent encoding accourding mongodb documentation: https://www.mongodb.com/docs/manual/reference/connection-string/#examples"
+}
+
 variable "database_users" {
   # type        = map(object({
   #   cidr_block = string


### PR DESCRIPTION
### What does this do?

Enable the component: `terraform-modules/aws/mongodb-atlas-user-list` which is turned on or off with the variable: `enable_percent_encoding_password`.

This enables the component to store the password in aws secret manager in percent-encoding mode; this in order to escape characters that damage the mongodb connection string.

**Documentation**:
https://www.mongodb.com/docs/manual/reference/connection-string/#examples
Bad strings: `: / ? # [ ] @`

**Testing**: 
`enable_percent_encoding_password` = true
![Screen Shot 2022-04-18 at 17 13 51](https://user-images.githubusercontent.com/19688747/163891486-cbf6fa0e-8f18-42e1-97ac-c566f3d08625.png)


