### PR TITLE
Mongo default alerts

### DIFF
--- a/terraform-modules/aws/mongodb-atlas-alerts/variables.tf
+++ b/terraform-modules/aws/mongodb-atlas-alerts/variables.tf
@@ -203,46 +203,46 @@ variable "default_alerts" {
       # If is "metric_threshold_config" set, then "threshold_config" is not needed
       threshold_config = []
     },
-    {
-      event_type   = "OUTSIDE_SERVERLESS_METRIC_THRESHOLD"
-      enabled      = true
-      notification = []
-      matcher      = []
-      # This can only be a list of 1
-      # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      metric_threshold_config = []
-      # This can only be a list of 1
-      # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      threshold_config = [
-        {
-          metric_name = "SERVERLESS_CONNECTIONS_PERCENT"
-          operator    = "GREATER_THAN"
-          threshold   = 80
-          units       = "RAW"
-          mode        = "AVERAGE"
-        }
-      ]
-    },
-    {
-      event_type   = "OUTSIDE_SERVERLESS_METRIC_THRESHOLD"
-      enabled      = true
-      notification = []
-      matcher      = []
-      # This can only be a list of 1
-      # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      metric_threshold_config = []
-      # This can only be a list of 1
-      # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      threshold_config = [
-        {
-          metric_name = "SERVERLESS_DATA_SIZE_TOTAL"
-          operator    = "GREATER_THAN"
-          threshold   = 0.75
-          units       = "TERABYTES"
-          mode        = "AVERAGE"
-        }
-      ]
-    },
+    # {
+    #   event_type   = "OUTSIDE_SERVERLESS_METRIC_THRESHOLD"
+    #   enabled      = true
+    #   notification = []
+    #   matcher      = []
+    #   # This can only be a list of 1
+    #   # If is "metric_threshold_config" set, then "threshold_config" is not needed
+    #   metric_threshold_config = []
+    #   # This can only be a list of 1
+    #   # If is "metric_threshold_config" set, then "threshold_config" is not needed
+    #   threshold_config = [
+    #     {
+    #       metric_name = "SERVERLESS_CONNECTIONS_PERCENT"
+    #       operator    = "GREATER_THAN"
+    #       threshold   = 80
+    #       units       = "RAW"
+    #       mode        = "AVERAGE"
+    #     }
+    #   ]
+    # },
+    # {
+    #   event_type   = "OUTSIDE_SERVERLESS_METRIC_THRESHOLD"
+    #   enabled      = true
+    #   notification = []
+    #   matcher      = []
+    #   # This can only be a list of 1
+    #   # If is "metric_threshold_config" set, then "threshold_config" is not needed
+    #   metric_threshold_config = []
+    #   # This can only be a list of 1
+    #   # If is "metric_threshold_config" set, then "threshold_config" is not needed
+    #   threshold_config = [
+    #     {
+    #       metric_name = "SERVERLESS_DATA_SIZE_TOTAL"
+    #       operator    = "GREATER_THAN"
+    #       threshold   = 0.75
+    #       units       = "TERABYTES"
+    #       mode        = "AVERAGE"
+    #     }
+    #   ]
+    # },
     {
       event_type   = "HOST_NOT_ENOUGH_DISK_SPACE"
       enabled      = true

--- a/terraform-modules/aws/mongodb-atlas-alerts/variables.tf
+++ b/terraform-modules/aws/mongodb-atlas-alerts/variables.tf
@@ -203,6 +203,8 @@ variable "default_alerts" {
       # If is "metric_threshold_config" set, then "threshold_config" is not needed
       threshold_config = []
     },
+    # These alerts didnt work when trying to apply it.  Leaving it out for now.
+    # Returned a nondescriptive generic error.
     # {
     #   event_type   = "OUTSIDE_SERVERLESS_METRIC_THRESHOLD"
     #   enabled      = true

--- a/terraform-modules/aws/mongodb-atlas-alerts/variables.tf
+++ b/terraform-modules/aws/mongodb-atlas-alerts/variables.tf
@@ -210,7 +210,10 @@ variable "default_alerts" {
       matcher      = []
       # This can only be a list of 1
       # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      metric_threshold_config = [
+      metric_threshold_config = []
+      # This can only be a list of 1
+      # If is "metric_threshold_config" set, then "threshold_config" is not needed
+      threshold_config = [
         {
           metric_name = "SERVERLESS_CONNECTIONS_PERCENT"
           operator    = "GREATER_THAN"
@@ -219,9 +222,6 @@ variable "default_alerts" {
           mode        = "AVERAGE"
         }
       ]
-      # This can only be a list of 1
-      # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      threshold_config = []
     },
     {
       event_type   = "OUTSIDE_SERVERLESS_METRIC_THRESHOLD"
@@ -230,7 +230,10 @@ variable "default_alerts" {
       matcher      = []
       # This can only be a list of 1
       # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      metric_threshold_config = [
+      metric_threshold_config = []
+      # This can only be a list of 1
+      # If is "metric_threshold_config" set, then "threshold_config" is not needed
+      threshold_config = [
         {
           metric_name = "SERVERLESS_DATA_SIZE_TOTAL"
           operator    = "GREATER_THAN"
@@ -239,9 +242,6 @@ variable "default_alerts" {
           mode        = "AVERAGE"
         }
       ]
-      # This can only be a list of 1
-      # If is "metric_threshold_config" set, then "threshold_config" is not needed
-      threshold_config = []
     },
     {
       event_type   = "HOST_NOT_ENOUGH_DISK_SPACE"


### PR DESCRIPTION
Removing alerts that are not able to be applied.  It returns an error when trying to apply.