### PR TITLE
Cert Manager Update

### DIFF
--- a/.github/workflows/terragrunt-dev.yaml
+++ b/.github/workflows/terragrunt-dev.yaml
@@ -196,7 +196,7 @@ jobs:
           # TF_LOG: DEBUG
 
       - name: Terragrunt Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: the-commons-project/terragrunt-github-actions@master
         with:
           tf_actions_version: ${{ env.tf_version }}

--- a/.github/workflows/terragrunt-dev.yaml
+++ b/.github/workflows/terragrunt-dev.yaml
@@ -196,7 +196,7 @@ jobs:
           # TF_LOG: DEBUG
 
       - name: Terragrunt Apply
-        # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: the-commons-project/terragrunt-github-actions@master
         with:
           tf_actions_version: ${{ env.tf_version }}

--- a/terraform-environments/aws/terragrunt-dev/us-east-1/terragrunt-dev/300-kubernetes/10-cert-manager/.terraform.lock.hcl
+++ b/terraform-environments/aws/terragrunt-dev/us-east-1/terragrunt-dev/300-kubernetes/10-cert-manager/.terraform.lock.hcl
@@ -1,23 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/gavinbunney/kubectl" {
-  version     = "1.14.0"
-  constraints = ">= 1.7.0"
-  hashes = [
-    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
-    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
-    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
-    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
-    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
-    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
-    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
-    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
-    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
-    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.13.0"
   constraints = ">= 2.23.0"

--- a/terraform-environments/aws/terragrunt-dev/us-east-1/terragrunt-dev/300-kubernetes/10-cert-manager/terragrunt.hcl
+++ b/terraform-environments/aws/terragrunt-dev/us-east-1/terragrunt-dev/300-kubernetes/10-cert-manager/terragrunt.hcl
@@ -4,7 +4,7 @@ include {
 }
 
 terraform {
-  source = "github.com/ManagedKube/kubernetes-ops//terraform-modules/aws/helm/cert-manager?ref=cert-manager-update"
+  source = "github.com/ManagedKube/kubernetes-ops//terraform-modules/aws/helm/cert-manager?ref=v2.0.22"
 }
 
 dependency "eks" {

--- a/terraform-environments/aws/terragrunt-dev/us-east-1/terragrunt-dev/300-kubernetes/10-cert-manager/terragrunt.hcl
+++ b/terraform-environments/aws/terragrunt-dev/us-east-1/terragrunt-dev/300-kubernetes/10-cert-manager/terragrunt.hcl
@@ -4,7 +4,7 @@ include {
 }
 
 terraform {
-  source = "github.com/ManagedKube/kubernetes-ops//terraform-modules/aws/helm/cert-manager?ref=v1.0.29"
+  source = "github.com/ManagedKube/kubernetes-ops//terraform-modules/aws/helm/cert-manager?ref=cert-manager-update"
 }
 
 dependency "eks" {

--- a/terraform-modules/aws/helm/cert-manager/main.tf
+++ b/terraform-modules/aws/helm/cert-manager/main.tf
@@ -3,15 +3,6 @@ locals {
   official_chart_name = "cert-manager"
 }
 
-terraform {
-  required_providers {
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.7.0"
-    }
-  }
-}
-
 module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "3.6.0"

--- a/terraform-modules/aws/helm/cert-manager/main.tf
+++ b/terraform-modules/aws/helm/cert-manager/main.tf
@@ -115,7 +115,7 @@ data "template_file" "dns01_cluster_issuer_yaml" {
 
 resource "kubernetes_manifest" "dns01_cluster_issuer" {
   count    = var.enable_dns01_cluster_issuer
-  manifest = data.template_file.dns01_cluster_issuer_yaml.rendered
+  manifest = yamldecode(data.template_file.dns01_cluster_issuer_yaml.rendered)
 
   depends_on = [
     module.cert-manager
@@ -139,7 +139,7 @@ data "template_file" "http01_cluster_issuer_yaml" {
 
 resource "kubernetes_manifest" "http01_cluster_issuer" {
   count    = var.enable_http01_cluster_issuer
-  manifest = data.template_file.http01_cluster_issuer_yaml.rendered
+  manifest = yamldecode(data.template_file.http01_cluster_issuer_yaml.rendered)
 
   depends_on = [
     module.cert-manager

--- a/terraform-modules/aws/helm/cert-manager/main.tf
+++ b/terraform-modules/aws/helm/cert-manager/main.tf
@@ -113,9 +113,9 @@ data "template_file" "dns01_cluster_issuer_yaml" {
   }
 }
 
-resource "kubectl_manifest" "dns01_cluster_issuer" {
-  count     = var.enable_dns01_cluster_issuer
-  yaml_body = data.template_file.dns01_cluster_issuer_yaml.rendered
+resource "kubernetes_manifest" "dns01_cluster_issuer" {
+  count    = var.enable_dns01_cluster_issuer
+  manifest = data.template_file.dns01_cluster_issuer_yaml.rendered
 
   depends_on = [
     module.cert-manager
@@ -137,9 +137,9 @@ data "template_file" "http01_cluster_issuer_yaml" {
   }
 }
 
-resource "kubectl_manifest" "http01_cluster_issuer" {
-  count     = var.enable_http01_cluster_issuer
-  yaml_body = data.template_file.http01_cluster_issuer_yaml.rendered
+resource "kubernetes_manifest" "http01_cluster_issuer" {
+  count    = var.enable_http01_cluster_issuer
+  manifest = data.template_file.http01_cluster_issuer_yaml.rendered
 
   depends_on = [
     module.cert-manager


### PR DESCRIPTION
The `kubectl_manifest` terraform resource is a third party module that applies kubernetes yaml.  Switching over the usage to the hashicorp module that does the same thing `kubernetes_manifest`.  It will be less headache going forward using the first party module and have to pull in less stuff.