### PR TITLE
CR-150 Security Group Default Management

### DIFF
--- a/terraform-modules/aws/vpc/main.tf
+++ b/terraform-modules/aws/vpc/main.tf
@@ -38,6 +38,14 @@ module "vpc" {
     "kubernetes.io/role/internal-elb"           = "1"
     "ops_purpose"                               = "Overloaded for k8s worker usage"
   }
-
+  
   tags = var.tags
+
+  #Default Security Group Management (Default: secure)
+  manage_default_security_group   = var.manage_default_security_group
+  default_security_group_name     = var.default_security_group_name
+  default_security_group_egress   = var.default_security_group_egress
+  default_security_group_ingress  = var.default_security_group_ingress
+  default_security_group_tags     = var.default_security_group_tags
+  
 }

--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -91,7 +91,16 @@ variable "default_security_group_name" {
 variable "default_security_group_egress" {
   description = "List of maps of egress rules to set on the default security group"
   type        = list(map(string))
-  default     = ["0.0.0.0/0"]
+  default     = [
+    {
+      cidr_blocks = "0.0.0.0/0"
+      description = "Allow all"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    }
+  ]
 }
 
 variable "default_security_group_ingress" {

--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -97,7 +97,7 @@ variable "default_security_group_egress" {
 variable "default_security_group_ingress" {
   description = "List of maps of ingress rules to set on the default security group	"
   type        = list(map(string))
-  default     = []
+  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10"]
 }
 
 variable "default_security_group_tags" {

--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -106,7 +106,40 @@ variable "default_security_group_egress" {
 variable "default_security_group_ingress" {
   description = "List of maps of ingress rules to set on the default security group	"
   type        = list(map(string))
-  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10"]
+  default     = [
+    {
+      cidr_blocks = "10.0.0.0/8"
+      description = "rfc1918: Private Address Space"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    },
+    {
+      cidr_blocks = "172.16.0.0/12"
+      description = "rfc1918: Private Address Space"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    },
+    {
+      cidr_blocks = "192.168.0.0/16"
+      description = "rfc1918: Private Address Space"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    },
+    {
+      cidr_blocks = "100.64.0.0/10"
+      description = "rfc6598: Private Address Space"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    }
+  ]
 }
 
 variable "default_security_group_tags" {

--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -85,7 +85,7 @@ variable "manage_default_security_group" {
 variable "default_security_group_name" {
   description = "Name to be used on the default security group	"
   type        = string
-  default     = "sgdefault"
+  default     = "default"
 }
 
 variable "default_security_group_egress" {

--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -91,7 +91,7 @@ variable "default_security_group_name" {
 variable "default_security_group_egress" {
   description = "List of maps of egress rules to set on the default security group"
   type        = list(map(string))
-  default     = []
+  default     = ["0.0.0.0/0"]
 }
 
 variable "default_security_group_ingress" {

--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -85,7 +85,7 @@ variable "manage_default_security_group" {
 variable "default_security_group_name" {
   description = "Name to be used on the default security group	"
   type        = string
-  default     = "default"
+  default     = "sgdefault"
 }
 
 variable "default_security_group_egress" {

--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -74,3 +74,35 @@ variable "external_nat_ip_ids" {
   type        = list(string)
   default     = []
 }
+
+#Default Security Group Management (Default: secure)
+variable "manage_default_security_group" {
+  description = "Should be true to adopt and manage default security group"
+  type        = bool
+  default     = true
+}
+
+variable "default_security_group_name" {
+  description = "Name to be used on the default security group	"
+  type        = string
+  default     = "default"
+}
+
+variable "default_security_group_egress" {
+  description = "List of maps of egress rules to set on the default security group"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "default_security_group_ingress" {
+  description = "List of maps of ingress rules to set on the default security group	"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "default_security_group_tags" {
+  description = "Additional tags for the default security group	"
+  type    = map(any)
+  default = {}
+}
+


### PR DESCRIPTION
### **What does this do?**
When creating a `VPC`, the module also creates a default security group; this module will continue to create it but in a secure way.
- Allows all outbound traffic rules
- Allows RFC1918 and rfc6598 in inbouand traffic rules