### PR TITLE
Aws s3 encrypt update

### DIFF
--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -1,6 +1,6 @@
 resource "aws_kms_key" "kms_key" {
   description             = "This key is used to encrypt bucket objects"
-  deletion_window_in_days = 10
+  deletion_window_in_days = var.deletion_window_in_days
 
   enable_key_rotation = var.enable_key_rotation
 

--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -5,7 +5,6 @@ resource "aws_kms_key" "kms_key" {
 
 resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket
-  policy = var.policy
 
   tags = var.tags
 }
@@ -29,4 +28,9 @@ resource "aws_s3_bucket_public_access_block" "acl" {
   ignore_public_acls      = var.ignore_public_acls
   restrict_public_buckets = var.restrict_public_buckets
 
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = aws_s3_bucket.bucket.id
+  policy = var.policy
 }

--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -1,16 +1,23 @@
+resource "aws_kms_key" "kms_key" {
+  description             = "This key is used to encrypt bucket objects"
+  deletion_window_in_days = 10
+}
+
 resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket
   acl    = var.acl
   policy = var.policy
 
   tags = var.tags
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
-      }
-      bucket_key_enabled = true
+resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
+  bucket = aws_s3_bucket.bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.kms_key.arn
+      sse_algorithm     = "aws:kms"
     }
   }
 }

--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -5,7 +5,6 @@ resource "aws_kms_key" "kms_key" {
 
 resource "aws_s3_bucket" "bucket" {
   bucket = var.bucket
-  acl    = var.acl
   policy = var.policy
 
   tags = var.tags

--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -2,6 +2,8 @@ resource "aws_kms_key" "kms_key" {
   description             = "This key is used to encrypt bucket objects"
   deletion_window_in_days = 10
 
+  enable_key_rotation = var.enable_key_rotation
+
   tags = var.tags
 }
 

--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -1,6 +1,8 @@
 resource "aws_kms_key" "kms_key" {
   description             = "This key is used to encrypt bucket objects"
   deletion_window_in_days = 10
+
+  tags = var.tags
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -43,3 +43,9 @@ variable "enable_key_rotation " {
   description = "(Optional) Specifies whether key rotation is enabled. Defaults to false."
   default     = true
 }
+
+variable "deletion_window_in_days" {
+  type        = number
+  description = "(Optional) The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key."
+  default     = 10
+}

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -38,7 +38,7 @@ variable "policy" {
   default     = null
 }
 
-variable "enable_key_rotation " {
+variable "enable_key_rotation" {
   type        = bool
   description = "(Optional) Specifies whether key rotation is enabled. Defaults to false."
   default     = true

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -37,3 +37,9 @@ variable "policy" {
   type        = string
   default     = null
 }
+
+variable "enable_key_rotation " {
+  type        = bool
+  description = "(Optional) Specifies whether key rotation is enabled. Defaults to false."
+  default     = true
+}

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -13,11 +13,6 @@ variable "bucket" {
   description = "The name of the bucket. If omitted, Terraform will assign a random, unique name. Must be less than or equal to 63 characters in length."
 }
 
-variable "acl" {
-  type        = string
-  description = "The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, and log-delivery-write. Defaults to private. Conflicts with grant."
-}
-
 variable "block_public_acls" {
   type        = bool
   description = "Whether Amazon S3 should block public ACLs for this bucket."


### PR DESCRIPTION
The AWS S3 bucket Terraform resources has been splitting up the bucket configuration composition into different resources.  The usage in here was deprecated and this PR updates all of the deprecated items to use the newer items.  It is backwards compatible.