### PR TITLE
aws-s3-encrypt-update-2

### DIFF
--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -13,12 +13,11 @@ resource "aws_s3_bucket" "bucket" {
   tags = var.tags
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "example" {
+resource "aws_s3_bucket_server_side_encryption_configuration" "encryption_config" {
   bucket = aws_s3_bucket.bucket.bucket
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.kms_key.arn
       sse_algorithm     = "aws:kms"
     }
   }


### PR DESCRIPTION
The AWS S3 bucket Terraform resources has been splitting up the bucket configuration composition into different resources. The usage in here was deprecated and this PR updates all of the deprecated items to use the newer items. It is backwards compatible.