### PR TITLE
EKS - Auth - Back to regular auth config map usage

### DIFF
--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -32,7 +32,7 @@ resource "aws_kms_key" "eks" {
 
 module "eks" {
   source           = "terraform-aws-modules/eks/aws"
-  version          = "18.7.2"
+  version          = "18.23.0"
   cluster_name     = var.cluster_name
   cluster_version  = var.cluster_version
   enable_irsa      = var.enable_irsa

--- a/terraform-modules/aws/eks/variables.tf
+++ b/terraform-modules/aws/eks/variables.tf
@@ -50,7 +50,7 @@ variable "cluster_endpoint_public_access_cidrs" {
   description = "Kube API public endpoint allow access cidrs"
 }
 
-variable "map_roles" {
+variable "aws_auth_roles" {
   type = list(any)
   default = [
     {
@@ -62,7 +62,7 @@ variable "map_roles" {
   description = "A list of roles to give permission to access this cluster"
 }
 
-variable "map_users" {
+variable "aws_auth_users" {
   type = list(any)
   default = [
     {
@@ -79,7 +79,7 @@ variable "map_users" {
   description = "A list of users to give permission to access this cluster"
 }
 
-variable "map_accounts" {
+variable "aws_auth_accounts" {
   description = "Additional AWS account numbers to add to the aws-auth configmap."
   type        = list(string)
   default     = []


### PR DESCRIPTION
Prior to this, the AWS EKS module said it shouldnt handle the kubernetes auth configmap which means that the user of this module has to do it on their own.  Which we did.  It now looks like they have reverted that stance and the module manages the auth config map again.  We are reverting our usage back to this.