### PR TITLE
enabled rotation for kms eks cluster

### DIFF
--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -27,6 +27,7 @@ provider "kubernetes" {
 
 resource "aws_kms_key" "eks" {
   description = "EKS Secret Encryption Key"
+  enable_key_rotation = var.cluster_kms_enable_rotation
   tags        = var.tags
 }
 

--- a/terraform-modules/aws/eks/variables.tf
+++ b/terraform-modules/aws/eks/variables.tf
@@ -242,5 +242,5 @@ variable "node_security_group_additional_rules" {
 variable "cluster_kms_enable_rotation" {
   type        = bool
   default     = true
-  description = "(Optional) Specifies whether key rotation is enabled. Defaults to false."
+  description = "(Optional) Specifies whether key rotation is enabled. Defaults to true."
 }

--- a/terraform-modules/aws/eks/variables.tf
+++ b/terraform-modules/aws/eks/variables.tf
@@ -241,6 +241,6 @@ variable "node_security_group_additional_rules" {
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key#enable_key_rotation
 variable "cluster_kms_enable_rotation" {
   type        = bool
-  default     = false
+  default     = true
   description = "(Optional) Specifies whether key rotation is enabled. Defaults to false."
 }

--- a/terraform-modules/aws/eks/variables.tf
+++ b/terraform-modules/aws/eks/variables.tf
@@ -237,3 +237,10 @@ variable "node_security_group_additional_rules" {
     # }
   }
 }
+
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key#enable_key_rotation
+variable "cluster_kms_enable_rotation" {
+  type        = bool
+  default     = false
+  description = "(Optional) Specifies whether key rotation is enabled. Defaults to false."
+}


### PR DESCRIPTION
**Context**
EKS cluster has a KMS key, the enabled rotation default of the flag is false

**What does this do?** 
-  add a new env var called: cluster_kms_enable_rotation pointing to the module: 

When you enable automatic key rotation for a KMS key, AWS KMS generates new cryptographic material for the KMS key every year. AWS KMS saves all previous versions of the cryptographic material in perpetuity so you can decrypt any data encrypted with that KMS key. AWS KMS does not delete any rotated key material until you [delete the KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html). You can [track the rotation](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#monitor-key-rotation) of key material for your KMS keys in Amazon CloudWatch and AWS CloudTrail.

https://github.com/ManagedKube/kubernetes-ops/pull/333