### PR TITLE
Feat bucket-owner-enforce s3

### DIFF
--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -57,3 +57,11 @@ resource "aws_s3_bucket_logging" "logging" {
   target_bucket = var.logging_bucket_name
   target_prefix = "log/"
 }
+
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
+  count = var.bucket_owner_enforced ? 1 : 0
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}

--- a/terraform-modules/aws/s3_bucket/main.tf
+++ b/terraform-modules/aws/s3_bucket/main.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket_logging" "logging" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
-  count = var.bucket_owner_enforced ? 1 : 0
+  count = var.enable_bucket_owner_enforced ? 1 : 0
   bucket = aws_s3_bucket.bucket.id
   rule {
     object_ownership = "BucketOwnerEnforced"

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -83,6 +83,12 @@ variable "logging_bucket_prefix" {
 variable "enable_bucket_owner_enforced" {
   type        = bool
   description = "BucketOwnerEnforced choice of object ownership, which is used to disable ACL-s."
-  default     = true
+  #Bucket owner enforced (recommended) – ACLs are disabled, and the bucket
+  #owner automatically owns and has full control over every object in the bucket. 
+  #ACLs no longer affect permissions to data in the S3 bucket. The bucket uses policies 
+  #to define access control.
+  #https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
+  default     = true 
+
 }
 

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -83,6 +83,6 @@ variable "logging_bucket_prefix" {
 variable "enable_bucket_owner_enforced" {
   type        = bool
   description = "BucketOwnerEnforced choice of object ownership, which is used to disable ACL-s."
-  default     = "false"
+  default     = true
 }
 

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -80,7 +80,7 @@ variable "logging_bucket_prefix" {
   default     = "s3-log/"
 }
 
-variable "bucket_owner_enforced" {
+variable "enable_bucket_owner_enforced" {
   type        = bool
   description = "BucketOwnerEnforced choice of object ownership, which is used to disable ACL-s."
   default     = "false"

--- a/terraform-modules/aws/s3_bucket/variables.tf
+++ b/terraform-modules/aws/s3_bucket/variables.tf
@@ -79,3 +79,10 @@ variable "logging_bucket_prefix" {
   description = "The prefix to add to the logs"
   default     = "s3-log/"
 }
+
+variable "bucket_owner_enforced" {
+  type        = bool
+  description = "BucketOwnerEnforced choice of object ownership, which is used to disable ACL-s."
+  default     = "false"
+}
+


### PR DESCRIPTION
**feat**: add bucket-owner-enforce s3

**what solves this?**
Security scanners such as [prowler](https://github.com/prowler-cloud/prowler) report this vulnerability with s3 buckets created with this module.
`Bucket name has bucket ACLs enabled!`
![Screen Shot 2022-06-21 at 10 21 59](https://user-images.githubusercontent.com/19688747/174849301-1007e111-a46c-4303-aadb-25714c684d67.png)

**how does it do it?**
Creates a new resource on demand 
```
resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
  count = var.enable_bucket_owner_enforced ? 1 : 0
  bucket = aws_s3_bucket.bucket.id
  rule {
    object_ownership = "BucketOwnerEnforced"
  }
}
```

**What is the result?**
- Plan:
```
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_s3_bucket_ownership_controls.bucket_ownership_controls[0] will be created
  + resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
      + bucket = "476264532441-x2-ops-prowler"
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerEnforced"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

```
- AWS Console
![Screen Shot 2022-06-21 at 10 35 06](https://user-images.githubusercontent.com/19688747/174852024-6b6c1398-b713-443e-bba6-052ec0fa6287.png)

- Prowlers Result
![Screen Shot 2022-06-21 at 10 38 44](https://user-images.githubusercontent.com/19688747/174852703-ca6a3d94-ba68-4409-919b-b1d7f147a3b1.png)

**refs**: https://github.com/hashicorp/terraform-provider-aws/issues/21980