### PR TITLE
Change 365 by default in retention days in cloudwatch 

### DIFF
--- a/terraform-modules/aws/eks/variables.tf
+++ b/terraform-modules/aws/eks/variables.tf
@@ -130,7 +130,7 @@ variable "cluster_enabled_log_types" {
 
 variable "cloudwatch_log_group_retention_in_days" {
   type        = number
-  default     = 90
+  default     = 365
   description = "Log retention in days"
 }
 


### PR DESCRIPTION
### Context

- Some solutions to scan vulnerabilities like [prowler](https://github.com/prowler-cloud/prowler) reports the following:

![Screen Shot 2022-06-27 at 10 48 53](https://user-images.githubusercontent.com/19688747/175993717-b74df8a9-93f7-4d31-b408-56f2613d6c77.png)

- Eks ManagedKube module has 90 days like default in log group cloud watch.
https://github.com/ManagedKube/kubernetes-ops/blob/b8f16f1434a7af52d2bbebbb818eaad7a6274f8d/terraform-modules/aws/eks/variables.tf#L131-L135


### What does this do?
- Set as default 365 days cloud watch log groups retentions
https://github.com/ManagedKube/kubernetes-ops/blob/8bb756ef66a4235bd37f895b70ab613079bdfd6e/terraform-modules/aws/eks/variables.tf#L131-L135

### Evidence of terraform apply
```
  # module.eks.aws_cloudwatch_log_group.this[0] will be updated in-place
~ resource "aws_cloudwatch_log_group" "this" {
id                = "/aws/eks/ops/cluster"
name              = "/aws/eks/ops/cluster"
~retention_in_days = 90 ->365
tags              = {
            "ops_env"              = "ops"
            "ops_managed_by"       = "terraform"
            "ops_owners"           = "devops"
            "ops_source_repo"      = "gruntwork-infrastructure-live"
            "ops_source_repo_path" = "ops/us-west-2/ops/p2a/0200-eks"
        }
# (2 unchanged attributes hidden)
    }
```

### What does this imply?
A retention policy is applied retroactively to existing objects in the bucket and also to new objects added later.
In the case of current customers who use the default in 90 days, they will have no problem as the retention interval is longer than the existing one.