### PR TITLE
Add Kms to cloudposse in cloud-trail-watch-alarms

### DIFF
--- a/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
+++ b/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "kms" {
   }
 
   statement {
-    sid    = "Allow KMS to CloudWatch Log Group ${var.name}"
+    sid    = "Allow KMS to CloudWatch Log Group ${element(var.attributes,0)}"
     effect = "Allow"
 
     actions = [
@@ -80,13 +80,13 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test = "ArnEquals"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.name}"]
+      values = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${${element(var.attributes,0)}"]
     }
   }
 }
 
 resource "aws_kms_key" "kms" {
-  description             = "KMS key for ${var.name}"
+  description             = "KMS key for ${element(var.attributes,0)"
   deletion_window_in_days = 10
   enable_key_rotation     = true
   policy                  = join("", data.aws_iam_policy_document.kms.*.json)

--- a/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
+++ b/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "kms" {
 }
 
 resource "aws_kms_key" "kms" {
-  description             = "KMS key for ${element(var.attributes,0)"
+  description             = "KMS key for ${element(var.attributes,0)}"
   deletion_window_in_days = 10
   enable_key_rotation     = true
   policy                  = join("", data.aws_iam_policy_document.kms.*.json)

--- a/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
+++ b/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "kms" {
     condition {
       test = "ArnEquals"
       variable = "kms:EncryptionContext:aws:logs:arn"
-      values = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${${element(var.attributes,0)}"]
+      values = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${element(var.attributes,0)}"]
     }
   }
 }

--- a/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
+++ b/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
@@ -1,12 +1,97 @@
-## Everything after this is standard cloudtrail setup
+locals {
+  arn_format  = "arn:${data.aws_partition.current.partition}"
+}
+data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
+## Everything after this is standard cloudtrail setup
 /*ToDo: We are collaborating with cloudposse to bring this solution to your project, we have the task of following up this pr to integrate it 
           and return to the direct version of cloudposse.
           
           Cloudposse' issue: New input variable s3_object_ownership cloudposse/terraform-aws-cloudtrail-s3-bucket#62
           Cloudposse' pr: add input var s3_object_ownership cloudposse/terraform-aws-cloudtrail-s3-bucket#63
 */
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A KMS 
+# We can attach KMS to CloudWatch Log.
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "kms" {
+  statement {
+    sid    = "Enable Root User Permissions"
+    effect = "Allow"
+
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:Tag*",
+      "kms:Untag*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    #bridgecrew:skip=CKV_AWS_109:This policy applies only to the key it is attached to
+    #bridgecrew:skip=CKV_AWS_111:This policy applies only to the key it is attached to
+    resources = [
+      "*"
+    ]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "${local.arn_format}:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow KMS to CloudWatch Log Group ${var.name}"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com"
+      ]
+    }
+    condition {
+      test = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.name}"]
+    }
+  }
+}
+
+resource "aws_kms_key" "kms" {
+  description             = "KMS key for ${var.name}"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = join("", data.aws_iam_policy_document.kms.*.json)
+}
+
 module "cloudtrail_s3_bucket" {
   source  = "github.com/ManagedKube/terraform-aws-cloudtrail-s3-bucket.git//?ref=0.24.0"
   #version = "master"
@@ -25,6 +110,7 @@ resource "aws_cloudwatch_log_group" "default" {
   tags              = module.this.tags
   retention_in_days = 365
   #prowler issue: https://github.com/prowler-cloud/prowler/issues/1229
+  kms_key_id = aws_kms_key.kms.arn
 }
 
 data "aws_iam_policy_document" "log_policy" {


### PR DESCRIPTION
### What does this do?
- Add kms to cloud watch log group.

### Evidence of apply
```
# aws_kms_key.kms will be created
  + resource "aws_kms_key" "kms" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 10
      + description                        = "KMS key for x2-ops-cloudtrail-cloudwatch-alarms"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "kms:Update*",
                          + "kms:Untag*",
                          + "kms:Tag*",
                          + "kms:ScheduleKeyDeletion",
                          + "kms:Revoke*",
                          + "kms:Put*",
                          + "kms:List*",
                          + "kms:Get*",
                          + "kms:Enable*",
                          + "kms:Disable*",
                          + "kms:Describe*",
                          + "kms:Delete*",
                          + "kms:Create*",
                          + "kms:CancelKeyDeletion",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::xxxxxxxxx:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable Root User Permissions"
                    },
                  + {
                      + Action    = [
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:Encrypt*",
                          + "kms:Describe*",
                          + "kms:Decrypt*",
                        ]
                      + Condition = {
                          + ArnEquals = {
                              + kms:EncryptionContext:aws:logs:arn = "arn:aws:logs:us-west-2:xxxxxxxxx:log-group:x2-ops-cloudtrail-cloudwatch-alarms"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "logs.us-west-2.amazonaws.com"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow KMS to CloudWatch Log Group x2-ops-cloudtrail-cloudwatch-alarms"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + tags_all                           = (known after apply)
    }

Plan: 1 to add, 2 to change, 0 to destroy.
╷
│ Warning: Argument is deprecated
│ 
│   with module.cloudtrail_s3_bucket.module.s3_access_log_bucket.aws_s3_bucket.default,
│   on .terraform/modules/cloudtrail_s3_bucket.s3_access_log_bucket/main.tf line 1, in resource "aws_s3_bucket" "default":
│    1: resource "aws_s3_bucket" "default" {
│ 
│ Use the aws_s3_bucket_versioning resource instead
│ 
│ (and 9 more similar warnings elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_kms_key.kms: Creating...
aws_kms_key.kms: Still creating... [10s elapsed]
aws_kms_key.kms: Creation complete after 11s [id=21a39fed-4db7-43b2-8219-bb01722bf05a]
aws_cloudwatch_log_group.default: Modifying... [id=x2-ops-cloudtrail-cloudwatch-alarms]
aws_cloudwatch_log_group.default: Modifications complete after 1s [id=x2-ops-cloudtrail-cloudwatch-alarms]
data.aws_iam_policy_document.log_policy: Reading... [id=1031456090]
data.aws_iam_policy_document.log_policy: Read complete after 0s [id=1031456090]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 1 added, 1 changed, 0 destroyed.

Outputs:

dashboard_combined = "https://console.aws.amazon.com/cloudwatch/home?region=us-west-2#dashboards:name=cis-benchmark-statistics-combined"
dashboard_individual = "https://console.aws.amazon.com/cloudwatch/home?region=us-west-2#dashboards:name=cis-benchmark-statistics-individual"
sns_topic_arn = "arn:aws:sns:us-west-2:xxxxxxx:cloudtrail-breach"
```


### Evidence of aws console
![Screen Shot 2022-06-30 at 10 48 22](https://user-images.githubusercontent.com/19688747/176733375-9b0cf11c-3cb5-4927-bb0b-7aa09b2aa71e.png)

![Screen Shot 2022-06-30 at 10 50 47](https://user-images.githubusercontent.com/19688747/176733772-3f02b2a9-5eb8-458c-bb0b-83d9d7ef7a82.png)


