### PR TITLE
Add kms to eks cloudwatch log group

### DIFF
--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -34,7 +34,7 @@ resource "aws_kms_key" "eks" {
 
 module "kms_cloudwatch_log_group" {
   source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=feat-kms-eks-cloud-watch"
-  log_group_name          = eks.outputs.cloudwatch_log_group_name
+  log_group_name          = module.eks.outputs.cloudwatch_log_group_name
   tags                    = var.tags
 }
 
@@ -65,7 +65,7 @@ module "eks" {
     resources        = ["secrets"]
   }]
 
-  cloudwatch_log_group_kms_key_id = kms_cloudwatch_log_group.outputs.kms_arn
+  cloudwatch_log_group_kms_key_id = module.kms_cloudwatch_log_group.outputs.kms_arn
   cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
   cluster_enabled_log_types     = var.cluster_enabled_log_types
 

--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -34,7 +34,7 @@ resource "aws_kms_key" "eks" {
 
 module "kms_cloudwatch_log_group" {
   source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=feat-kms-eks-cloud-watch"
-  log_group_name          = module.eks.outputs.cloudwatch_log_group_name
+  log_group_name          = module.eks.cloudwatch_log_group_name
   tags                    = var.tags
 }
 
@@ -65,7 +65,7 @@ module "eks" {
     resources        = ["secrets"]
   }]
 
-  cloudwatch_log_group_kms_key_id = module.kms_cloudwatch_log_group.outputs.kms_arn
+  cloudwatch_log_group_kms_key_id = module.kms_cloudwatch_log_group.kms_arn
   cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
   cluster_enabled_log_types     = var.cluster_enabled_log_types
 

--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -31,6 +31,14 @@ resource "aws_kms_key" "eks" {
   tags        = var.tags
 }
 
+
+module "kms_cloudwatch_log_group" {
+  source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/eks?ref=feat-kms-eks-cloud-watch"
+  log_group_name          = eks.cloudwatch_log_group_name
+  tags                    = var.tags
+}
+
+
 module "eks" {
   source           = "terraform-aws-modules/eks/aws"
   version          = "18.23.0"
@@ -57,6 +65,7 @@ module "eks" {
     resources        = ["secrets"]
   }]
 
+  cloudwatch_log_group_kms_key_id = kms_cloudwatch_log_group.kms_arn
   cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
   cluster_enabled_log_types     = var.cluster_enabled_log_types
 

--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -34,7 +34,7 @@ resource "aws_kms_key" "eks" {
 
 module "kms_cloudwatch_log_group" {
   source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=feat-kms-eks-cloud-watch"
-  log_group_name          = module.eks.cloudwatch_log_group_name
+  log_group_name          = "/aws/eks/${var.cluster_name}/cluster"
   tags                    = var.tags
 }
 

--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -34,7 +34,7 @@ resource "aws_kms_key" "eks" {
 
 module "kms_cloudwatch_log_group" {
   source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=feat-kms-eks-cloud-watch"
-  log_group_name          = eks.cloudwatch_log_group_name
+  log_group_name          = eks.outputs.cloudwatch_log_group_name
   tags                    = var.tags
 }
 
@@ -65,7 +65,7 @@ module "eks" {
     resources        = ["secrets"]
   }]
 
-  cloudwatch_log_group_kms_key_id = kms_cloudwatch_log_group.kms_arn
+  cloudwatch_log_group_kms_key_id = kms_cloudwatch_log_group.outputs.kms_arn
   cloudwatch_log_group_retention_in_days = var.cloudwatch_log_group_retention_in_days
   cluster_enabled_log_types     = var.cluster_enabled_log_types
 

--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -33,7 +33,7 @@ resource "aws_kms_key" "eks" {
 
 
 module "kms_cloudwatch_log_group" {
-  source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=feat-kms-eks-cloud-watch"
+  source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=v2.0.37"
   log_group_name          = "/aws/eks/${var.cluster_name}/cluster"
   tags                    = var.tags
 }

--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -33,7 +33,7 @@ resource "aws_kms_key" "eks" {
 
 
 module "kms_cloudwatch_log_group" {
-  source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/eks?ref=feat-kms-eks-cloud-watch"
+  source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=feat-kms-eks-cloud-watch"
   log_group_name          = eks.cloudwatch_log_group_name
   tags                    = var.tags
 }

--- a/terraform-modules/aws/kms/cloudwatch_log_group/README.md
+++ b/terraform-modules/aws/kms/cloudwatch_log_group/README.md
@@ -1,0 +1,36 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_key.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_log_group_name"></a> [log\_group\_name](#input\_log\_group\_name) | Log group name of cloud watch | `string` | `"log-group-default"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kms_arn"></a> [kms\_arn](#output\_kms\_arn) | Arn of kms for log group of cloudwatch |

--- a/terraform-modules/aws/kms/cloudwatch_log_group/main.tf
+++ b/terraform-modules/aws/kms/cloudwatch_log_group/main.tf
@@ -1,0 +1,88 @@
+# This is a standard kms that frees any cloud watch log group from vulnerabilities.
+
+locals {
+  arn_format  = "arn:${data.aws_partition.current.partition}"
+}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A KMS 
+# We can attach KMS to CloudWatch Log.
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "kms" {
+  statement {
+    sid    = "Enable Root User Permissions"
+    effect = "Allow"
+
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:Tag*",
+      "kms:Untag*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    #bridgecrew:skip=CKV_AWS_109:This policy applies only to the key it is attached to
+    #bridgecrew:skip=CKV_AWS_111:This policy applies only to the key it is attached to
+    resources = [
+      "*"
+    ]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "${local.arn_format}:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow KMS to CloudWatch Log Group ${var.log_group_name}"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com"
+      ]
+    }
+    condition {
+      test = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.log_group_name}"]
+    }
+  }
+}
+
+resource "aws_kms_key" "kms" {
+  description             = "KMS key for log-group: ${var.log_group_name}"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = join("", data.aws_iam_policy_document.kms.*.json)
+  tags                    = var.tags
+}

--- a/terraform-modules/aws/kms/cloudwatch_log_group/main.tf
+++ b/terraform-modules/aws/kms/cloudwatch_log_group/main.tf
@@ -1,4 +1,5 @@
 # This is a standard kms that frees any cloud watch log group from vulnerabilities.
+# Docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
 
 locals {
   arn_format  = "arn:${data.aws_partition.current.partition}"

--- a/terraform-modules/aws/kms/cloudwatch_log_group/outputs.tf
+++ b/terraform-modules/aws/kms/cloudwatch_log_group/outputs.tf
@@ -1,0 +1,4 @@
+output "kms_arn" {
+  description = "Arn of kms for log group of cloudwatch"
+  value       = aws_kms_key.kms.arn
+}

--- a/terraform-modules/aws/kms/cloudwatch_log_group/variables.tf
+++ b/terraform-modules/aws/kms/cloudwatch_log_group/variables.tf
@@ -1,0 +1,9 @@
+variable "log_group_name" {
+  type        = string
+  default     = "log-group-default"
+  description = "Log group name of cloud watch"
+}
+
+variable "tags" {
+  type = map(any)
+}


### PR DESCRIPTION
### What does this do?
- Create a new module called kms/cloudwatch_log_group: https://github.com/ManagedKube/kubernetes-ops/blob/571db96641b25483de84fdde4491401d4d0107c7/terraform-modules/aws/eks/main.tf#L35-L39
- This module is consuming by eks to asociate an standard kms for log groups.
- One of the advantages is that this module can be used for future components that need cloudwatch log groups and wish to associate a kms that will free them from vulnerabilities.

### Terraform plan
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.eks.aws_cloudwatch_log_group.this[0] will be updated in-place
  ~ resource "aws_cloudwatch_log_group" "this" {
        id                = "/aws/eks/ops/cluster"
      + kms_key_id        = (known after apply)
        name              = "/aws/eks/ops/cluster"
        tags              = {
            "ops_env"              = "ops"
            "ops_managed_by"       = "terraform"
            "ops_owners"           = "devops"
            "ops_source_repo"      = "gruntwork-infrastructure-live"
            "ops_source_repo_path" = "ops/us-west-2/ops/p2a/0200-eks"
        }
        # (3 unchanged attributes hidden)
    }

  # module.kms_cloudwatch_log_group.aws_kms_key.kms will be created
  + resource "aws_kms_key" "kms" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 10
      + description                        = "KMS key for log-group: /aws/eks/ops/cluster"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "kms:Update*",
                          + "kms:Untag*",
                          + "kms:Tag*",
                          + "kms:ScheduleKeyDeletion",
                          + "kms:Revoke*",
                          + "kms:Put*",
                          + "kms:List*",
                          + "kms:Get*",
                          + "kms:Enable*",
                          + "kms:Disable*",
                          + "kms:Describe*",
                          + "kms:Delete*",
                          + "kms:Create*",
                          + "kms:CancelKeyDeletion",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::476264532441:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable Root User Permissions"
                    },
                  + {
                      + Action    = [
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:Encrypt*",
                          + "kms:Describe*",
                          + "kms:Decrypt*",
                        ]
                      + Condition = {
                          + ArnEquals = {
                              + kms:EncryptionContext:aws:logs:arn = "arn:aws:logs:us-west-2:476264532441:log-group:/aws/eks/ops/cluster"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "logs.us-west-2.amazonaws.com"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow KMS to CloudWatch Log Group /aws/eks/ops/cluster"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + tags                               = {
          + "ops_env"              = "ops"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "ops/us-west-2/ops/p2a/0200-eks"
        }
      + tags_all                           = {
          + "ops_env"              = "ops"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "ops/us-west-2/ops/p2a/0200-eks"
        }
    }

Plan: 1 to add, 1 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
```
### Evidence in aws console
![Screen Shot 2022-07-06 at 15 08 10](https://user-images.githubusercontent.com/19688747/177643469-aaa9124a-dfa1-4920-a90b-136b022faff6.png)

