### PR TITLE
rfc1918 and rfc6598 in default_security_group_egress

### DIFF
--- a/terraform-modules/aws/vpc/variables.tf
+++ b/terraform-modules/aws/vpc/variables.tf
@@ -89,12 +89,36 @@ variable "default_security_group_name" {
 }
 
 variable "default_security_group_egress" {
-  description = "List of maps of egress rules to set on the default security group"
+ description = "List of maps of egress rules to set on the default security group	"
   type        = list(map(string))
   default     = [
     {
-      cidr_blocks = "0.0.0.0/0"
-      description = "Allow all"
+      cidr_blocks = "10.0.0.0/8"
+      description = "rfc1918: Private Address Space"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    },
+    {
+      cidr_blocks = "172.16.0.0/12"
+      description = "rfc1918: Private Address Space"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    },
+    {
+      cidr_blocks = "192.168.0.0/16"
+      description = "rfc1918: Private Address Space"
+      from_port   = 0
+      protocol    = "-1"
+      self        = false
+      to_port     = 0
+    },
+    {
+      cidr_blocks = "100.64.0.0/10"
+      description = "rfc6598: Private Address Space"
       from_port   = 0
       protocol    = "-1"
       self        = false


### PR DESCRIPTION
### What does this do?
- Change default_security_group_egress default by rfc ips instead of 0.0.0.0


### Evidence in AWS console
![Screen Shot 2022-07-11 at 17 39 30](https://user-images.githubusercontent.com/19688747/178376457-6553482d-98a4-43e6-a8ea-f0f97c7bb4ab.png)


### Terraform apply
Terraform will perform the following actions:

```
  # module.vpc.aws_default_security_group.this[0] will be updated in-place
  ~ resource "aws_default_security_group" "this" {
      ~ egress                 = [
          + {
              + cidr_blocks      = [
                  + "10.0.0.0/8",
                ]
              + description      = "rfc1918: Private Address Space"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
          + {
              + cidr_blocks      = [
                  + "100.64.0.0/10",
                ]
              + description      = "rfc6598: Private Address Space"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
          + {
              + cidr_blocks      = [
                  + "172.16.0.0/12",
                ]
              + description      = "rfc1918: Private Address Space"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
          + {
              + cidr_blocks      = [
                  + "192.168.0.0/16",
                ]
              + description      = "rfc1918: Private Address Space"
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
        id                     = "sg-0e7e4369dbd2ddf15"
        name                   = "default"
        tags                   = {
            "Name"                 = "default"
            "ops_env"              = "ops"
            "ops_managed_by"       = "terraform"
            "ops_owners"           = "devops"
            "ops_source_repo"      = "gruntwork-infrastructure-live"
            "ops_source_repo_path" = "ops/us-west-2/ops/p2a/0100-vpc"
        }
        # (7 unchanged attributes hidden)
    }
```