### PR TITLE
fix kms version v2.0.40

### DIFF
--- a/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
+++ b/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {}
 
 module "kms_cloudwatch_log_group" {
   count                       = var.kms_cloudwatch_loggroup_enable ? 1 : 0
-  source                      = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=v2.0.39"
+  source                      = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=v2.0.40"
   log_group_name              = element(var.attributes, 0)
   kms_deletion_window_in_days = var.kms_cloudwatch_loggroup_deletion_window_in_days
   kms_enable_key_rotation     = var.kms_cloudwatch_loggroup_kms_enable_key_rotation
@@ -13,7 +13,7 @@ module "kms_cloudwatch_log_group" {
 
 module "kms_cloudtrail" {
   count                       = var.kms_cloudtrail_enable ? 1 : 0
-  source                      = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudtrail?ref=v2.0.39"
+  source                      = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudtrail?ref=v2.0.40"
   cloudtrail_name             = element(var.attributes, 0)
   kms_deletion_window_in_days = var.kms_cloudtrail_deletion_window_in_days
   kms_enable_key_rotation     = var.kms_cloudtrail_kms_enable_key_rotation


### PR DESCRIPTION
Need to merge this pr and generate the v2.0.41 version 

Because version 2.0.39 does not have the kms trail changes.
https://github.com/ManagedKube/kubernetes-ops/blob/6124ac58ac389e233701bc1fcf6ee2f47c89ae22/terraform-modules/aws/cloudposse/aws-cloudtrail-cloudwatch-alarms/main.tf#L6-L16