### PR TITLE
Editing expected response for testkube

### DIFF
--- a/terraform-modules/aws/testkube/base-tests/test-suites/infra-base/yaml/prometheus-endpoint.yaml
+++ b/terraform-modules/aws/testkube/base-tests/test-suites/infra-base/yaml/prometheus-endpoint.yaml
@@ -12,7 +12,7 @@ spec:
             "http://prometheus-operated.monitoring.svc:9090/-/ready"
           ],
           "expected_status": "200",
-          "expected_body": "Prometheus is Ready."
+          "expected_body": "Prometheus"
       }
     type: string
   type: curl/test


### PR DESCRIPTION
The output for the newest version of the prometheus included in the kube-prometheus-stack for the health check has changed (argg!!!).  Updating the text response to be more generic.  This change is backwards compatible with older prometheus versions as well.

```
kubectl -n istio-system exec -it istio-ingressgateway-6d7b845966-cn44n -- bash
istio-proxy@istio-ingressgateway-6d7b845966-cn44n:/$ curl
curl: try 'curl --help' or 'curl --manual' for more information
istio-proxy@istio-ingressgateway-6d7b845966-cn44n:/$ curl -v http://prometheus-operated.monitoring.svc:9090/-/ready
*   Trying 10.117.195.25:9090...
* TCP_NODELAY set
* Connected to prometheus-operated.monitoring.svc (10.117.195.25) port 9090 (#0)
> GET /-/ready HTTP/1.1
> Host: prometheus-operated.monitoring.svc:9090
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Thu, 18 Aug 2022 20:26:31 GMT
< Content-Length: 28
< Content-Type: text/plain; charset=utf-8
< 
Prometheus Server is Ready.
```