### PR TITLE
IAM generic module

### DIFF
--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -38,161 +38,102 @@ No modules.
 | <a name="output_iam_arn"></a> [iam\_arn](#output\_iam\_arn) | Amazon Resource Name (ARN) specifying the role. |
 
 
-## How to use the module?
-1. Input values
-  ```
-iam_name                  = local.iam_rolename
+## Example Usage
+Here are some examples of how we can consume the module from terragrunt through inputs.
+
+1. IAM Role Basic Example With Managed Policy Attached
+You can create a basic iam role with Managed Policy Attached
+The iam_managed_policy_arns input param allows an array with one or more managed policies
+```
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  iam_name                  = local.iam_rolename
   iam_description           = local.iam_description
   iam_force_detach_policies = true
-  iam_managed_policy_arns   = ["arn:aws:iam::aws:policy/ReadOnlyAccess"] #you can add more than one policy
-  iam_assume_role_policy    = templatefile("assume_role_policy.json", { some parameters}) # This json is for the trusted policy
-  iam_inline_policy         = templatefile("prowler-additions-plus-s3-policy.json", {}) # You can add in line policy created by you
+  iam_managed_policy_arns   = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
   tags                      = local.tags
+}
+```
+2. Role With Inline policy 
+You can create a Iam Role with your own inline policy
+
+2.1 Create a new policy file (example: mypolicy.json)
+```
+{
+    "Id": "ExamplePolicy",
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowSSLRequestsOnly",
+        "Action": "s3:*",
+        "Effect": "Deny",
+        "Resource": [
+          "arn:aws:s3:::${bucket_name}",
+          "arn:aws:s3:::${bucket_name}/*"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+        },
+        "Principal": "*"
+      }
+    ]
+  }
+```
+```
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  iam_name                  = local.iam_rolename
+  iam_description           = local.iam_description
+  iam_force_detach_policies = true
+  input_iam_inline_policy   = templatefile("mypolicy.json", { bucket_name="my_bucket_name" })
+  tags                      = local.tags
+}
 ```
 
-2. Terraform Apply Log
+3. Role With Trusted relationship policy
+Trust relationship – This policy defines which principals can assume the role, 
+and under which conditions. This is sometimes referred to as a resource-based policy 
+for the IAM role. We’ll refer to this policy simply as the ‘trust policy’. 
+
+3.1 You can create a file (example: assume_role_policy.json)
 ```
-aws-vault exec exact-ops -- terragrunt apply
-Acquiring state lock. This may take a few moments...
-
-An execution plan has been generated and is shown below.
-Resource actions are indicated with the following symbols:
-  + create
-
-Terraform will perform the following actions:
-
-  # aws_iam_role.this will be created
-  + resource "aws_iam_role" "this" {
-      + arn                   = (known after apply)
-      + assume_role_policy    = jsonencode(
+{
+    {
+        "Version": "2012-10-17",
+        "Statement": [
             {
-              + Statement = [
-                  + {
-                      + Action    = "sts:AssumeRole"
-                      + Condition = {
-                          + StringEquals = {
-                              + sts:ExternalId = "xxxxxxxxxx"
-                            }
-                        }
-                      + Effect    = "Allow"
-                      + Principal = {
-                          + AWS = "arn:aws:iam::xxxxxxxx:root"
-                        }
-                    },
-                ]
-              + Version   = "2012-10-17"
-            }
-        )
-      + create_date           = (known after apply)
-      + description           = "x2-ops-tenable-scan: Specific read-only role for tenable scans in aws account"
-      + force_detach_policies = true
-      + id                    = (known after apply)
-      + managed_policy_arns   = [
-          + "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ]
-      + max_session_duration  = 3600
-      + name                  = "x2-ops-tenable-scan"
-      + name_prefix           = (known after apply)
-      + path                  = "/"
-      + tags                  = {
-          + "ops_env"              = "ops"
-          + "ops_managed_by"       = "terraform"
-          + "ops_owners"           = "devops"
-          + "ops_source_repo"      = "gruntwork-infrastructure-live"
-          + "ops_source_repo_path" = "xxxx/tenable-scan"
-        }
-      + tags_all              = {
-          + "ops_env"              = "ops"
-          + "ops_managed_by"       = "terraform"
-          + "ops_owners"           = "devops"
-          + "ops_source_repo"      = "xxxxxx"
-          + "ops_source_repo_path" = "xxxxxxx/tenable-scan"
-        }
-      + unique_id             = (known after apply)
-
-      + inline_policy {
-          + name   = "x2-ops-tenable-scan"
-          + policy = jsonencode(
-                {
-                  + Statement = [
-                      + {
-                          + Action   = [
-                              + "s3:ListBucket",
-                            ]
-                          + Effect   = "Allow"
-                          + Resource = [
-                              + "arn:aws:s3:::testing",
-                            ]
-                        },
-                      + {
-                          + Action   = [
-                              + "s3:PutObject",
-                              + "s3:GetObject",
-                              + "s3:DeleteObject",
-                              + "s3:PutObjectAcl",
-                            ]
-                          + Effect   = "Allow"
-                          + Resource = [
-                              + "arn:aws:s3:::testing/*",
-                            ]
-                        },
-                      + {
-                          + Action   = [
-                              + "ds:Get*",
-                              + "ds:Describe*",
-                              + "ds:List*",
-                              + "ec2:GetEbsEncryptionByDefault",
-                              + "ecr:Describe*",
-                              + "elasticfilesystem:DescribeBackupPolicy",
-                              + "glue:GetConnections",
-                              + "glue:GetSecurityConfiguration",
-                              + "glue:SearchTables",
-                              + "lambda:GetFunction",
-                              + "s3:GetAccountPublicAccessBlock",
-                              + "shield:DescribeProtection",
-                              + "shield:GetSubscriptionState",
-                              + "ssm:GetDocument",
-                              + "support:Describe*",
-                              + "tag:GetTagKeys",
-                            ]
-                          + Effect   = "Allow"
-                          + Resource = "*"
-                          + Sid      = "AllowMoreReadForProwler"
-                        },
-                      + {
-                          + Action   = [
-                              + "apigateway:GET",
-                            ]
-                          + Effect   = "Allow"
-                          + Resource = [
-                              + "arn:aws:apigateway:*::/restapis/*",
-                            ]
-                        },
-                    ]
-                  + Version   = "2012-10-17"
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "${account_id}"
+                },
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                    "StringEquals": {
+                        "sts:ExternalId": "${external_id}"
+                    }
                 }
-            )
-        }
+            }
+        ]
     }
-
-Plan: 1 to add, 0 to change, 0 to destroy.
-
-Changes to Outputs:
-  + iam_arn = (known after apply)
-
-Do you want to perform these actions?
-  Terraform will perform the actions described above.
-  Only 'yes' will be accepted to approve.
-
-  Enter a value: yes
-
-aws_iam_role.this: Creating...
-aws_iam_role.this: Creation complete after 2s [id=x2-ops-tenable-scan]
-
-Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
-Releasing state lock. This may take a few moments...
-
-Outputs:
-
-iam_arn = "arn:aws:iam::xxxxxxx:role/x2-ops-tenable-scan"
+```
+```
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  iam_name                  = local.iam_rolename
+  iam_description           = local.iam_description
+  iam_force_detach_policies = true
+  iam_assume_role_policy    = templatefile("assume_role_policy.json", { account_id = local.account_id, external_id = local.iam_external_id})
+  tags                      = local.tags
+}
 ```

--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -39,23 +39,17 @@ No modules.
 
 
 ## Example Usage
-Here are some examples of how we can consume the module from terragrunt through inputs.
+Here are some examples of how we can consume the module through the inputs variables.
 
 1. **IAM Role Basic Example With Managed Policy Attached**
 You can create a basic iam role with Managed Policy Attached
 The iam_managed_policy_arns input param allows an array with one or more managed policies
 ```
-# ---------------------------------------------------------------------------------------------------------------------
-# MODULE PARAMETERS
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-# ---------------------------------------------------------------------------------------------------------------------
-inputs = {
   iam_name                  = local.iam_rolename
   iam_description           = local.iam_description
   iam_force_detach_policies = true
   iam_managed_policy_arns   = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
   tags                      = local.tags
-}
 ```
 
 2. **Role With Inline policy** 
@@ -86,17 +80,11 @@ You can create a Iam Role with your own inline policy
     }
     ```
     ```
-    # ---------------------------------------------------------------------------------------------------------------------
-    # MODULE PARAMETERS
-    # These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-    # ---------------------------------------------------------------------------------------------------------------------
-    inputs = {
     iam_name                  = local.iam_rolename
     iam_description           = local.iam_description
     iam_force_detach_policies = true
     input_iam_inline_policy   = templatefile("mypolicy.json", { bucket_name="my_bucket_name" })
     tags                      = local.tags
-    }
     ```
 
 3. **Role With Trusted relationship policy**
@@ -126,15 +114,9 @@ for the IAM role. We’ll refer to this policy simply as the ‘trust policy’.
         }
     ```
     ```
-    # ---------------------------------------------------------------------------------------------------------------------
-    # MODULE PARAMETERS
-    # These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-    # ---------------------------------------------------------------------------------------------------------------------
-    inputs = {
     iam_name                  = local.iam_rolename
     iam_description           = local.iam_description
     iam_force_detach_policies = true
     iam_assume_role_policy    = templatefile("assume_role_policy.json", { account_id = local.account_id, external_id = local.iam_external_id})
     tags                      = local.tags
-    }
     ```

--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -1,0 +1,37 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_iam_description"></a> [iam\_description](#input\_iam\_description) | (Optional) Description of the role. | `string` | `"New Role created from ManagedKube Module"` | no |
+| <a name="input_iam_force_detach_policies"></a> [iam\_force\_detach\_policies](#input\_iam\_force\_detach\_policies) | (Optional) Whether to force detaching any policies the role has before destroying it | `bool` | `false` | no |
+| <a name="input_iam_inline_policy"></a> [iam\_inline\_policy](#input\_iam\_inline\_policy) | Json to create policy in line | `string` | `"{}"` | no |
+| <a name="input_iam_managed_policy_arns"></a> [iam\_managed\_policy\_arns](#input\_iam\_managed\_policy\_arns) | List of arn policies to attached | `list(string)` | `[]` | no |
+| <a name="input_iam_max_session_duration"></a> [iam\_max\_session\_duration](#input\_iam\_max\_session\_duration) | (Optional) Maximum session duration (in seconds) that you want to set for the specified role his setting can have a value from 1 hour to 12 hours. | `number` | `60` | no |
+| <a name="input_iam_name"></a> [iam\_name](#input\_iam\_name) | Friendly name of the role | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Key-value mapping of tags for the IAM role. If configured with a provider | `map(any)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_arn"></a> [iam\_arn](#output\_iam\_arn) | Amazon Resource Name (ARN) specifying the role. |

--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -36,3 +36,163 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_iam_arn"></a> [iam\_arn](#output\_iam\_arn) | Amazon Resource Name (ARN) specifying the role. |
+
+
+## How to use the module?
+1. Input values
+  ```
+iam_name                  = local.iam_rolename
+  iam_description           = local.iam_description
+  iam_force_detach_policies = true
+  iam_managed_policy_arns   = ["arn:aws:iam::aws:policy/ReadOnlyAccess"] #you can add more than one policy
+  iam_assume_role_policy    = templatefile("assume_role_policy.json", { some parameters}) # This json is for the trusted policy
+  iam_inline_policy         = templatefile("prowler-additions-plus-s3-policy.json", {}) # You can add in line policy created by you
+  tags                      = local.tags
+```
+
+2. Terraform Apply Log
+```
+aws-vault exec exact-ops -- terragrunt apply
+Acquiring state lock. This may take a few moments...
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # aws_iam_role.this will be created
+  + resource "aws_iam_role" "this" {
+      + arn                   = (known after apply)
+      + assume_role_policy    = jsonencode(
+            {
+              + Statement = [
+                  + {
+                      + Action    = "sts:AssumeRole"
+                      + Condition = {
+                          + StringEquals = {
+                              + sts:ExternalId = "xxxxxxxxxx"
+                            }
+                        }
+                      + Effect    = "Allow"
+                      + Principal = {
+                          + AWS = "arn:aws:iam::xxxxxxxx:root"
+                        }
+                    },
+                ]
+              + Version   = "2012-10-17"
+            }
+        )
+      + create_date           = (known after apply)
+      + description           = "x2-ops-tenable-scan: Specific read-only role for tenable scans in aws account"
+      + force_detach_policies = true
+      + id                    = (known after apply)
+      + managed_policy_arns   = [
+          + "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ]
+      + max_session_duration  = 3600
+      + name                  = "x2-ops-tenable-scan"
+      + name_prefix           = (known after apply)
+      + path                  = "/"
+      + tags                  = {
+          + "ops_env"              = "ops"
+          + "ops_managed_by"       = "terraform"
+          + "ops_owners"           = "devops"
+          + "ops_source_repo"      = "gruntwork-infrastructure-live"
+          + "ops_source_repo_path" = "xxxx/tenable-scan"
+        }
+      + tags_all              = {
+          + "ops_env"              = "ops"
+          + "ops_managed_by"       = "terraform"
+          + "ops_owners"           = "devops"
+          + "ops_source_repo"      = "xxxxxx"
+          + "ops_source_repo_path" = "xxxxxxx/tenable-scan"
+        }
+      + unique_id             = (known after apply)
+
+      + inline_policy {
+          + name   = "x2-ops-tenable-scan"
+          + policy = jsonencode(
+                {
+                  + Statement = [
+                      + {
+                          + Action   = [
+                              + "s3:ListBucket",
+                            ]
+                          + Effect   = "Allow"
+                          + Resource = [
+                              + "arn:aws:s3:::testing",
+                            ]
+                        },
+                      + {
+                          + Action   = [
+                              + "s3:PutObject",
+                              + "s3:GetObject",
+                              + "s3:DeleteObject",
+                              + "s3:PutObjectAcl",
+                            ]
+                          + Effect   = "Allow"
+                          + Resource = [
+                              + "arn:aws:s3:::testing/*",
+                            ]
+                        },
+                      + {
+                          + Action   = [
+                              + "ds:Get*",
+                              + "ds:Describe*",
+                              + "ds:List*",
+                              + "ec2:GetEbsEncryptionByDefault",
+                              + "ecr:Describe*",
+                              + "elasticfilesystem:DescribeBackupPolicy",
+                              + "glue:GetConnections",
+                              + "glue:GetSecurityConfiguration",
+                              + "glue:SearchTables",
+                              + "lambda:GetFunction",
+                              + "s3:GetAccountPublicAccessBlock",
+                              + "shield:DescribeProtection",
+                              + "shield:GetSubscriptionState",
+                              + "ssm:GetDocument",
+                              + "support:Describe*",
+                              + "tag:GetTagKeys",
+                            ]
+                          + Effect   = "Allow"
+                          + Resource = "*"
+                          + Sid      = "AllowMoreReadForProwler"
+                        },
+                      + {
+                          + Action   = [
+                              + "apigateway:GET",
+                            ]
+                          + Effect   = "Allow"
+                          + Resource = [
+                              + "arn:aws:apigateway:*::/restapis/*",
+                            ]
+                        },
+                    ]
+                  + Version   = "2012-10-17"
+                }
+            )
+        }
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + iam_arn = (known after apply)
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+
+aws_iam_role.this: Creating...
+aws_iam_role.this: Creation complete after 2s [id=x2-ops-tenable-scan]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+Releasing state lock. This may take a few moments...
+
+Outputs:
+
+iam_arn = "arn:aws:iam::xxxxxxx:role/x2-ops-tenable-scan"
+```

--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -41,7 +41,7 @@ No modules.
 ## Example Usage
 Here are some examples of how we can consume the module from terragrunt through inputs.
 
-1. IAM Role Basic Example With Managed Policy Attached
+1. **IAM Role Basic Example With Managed Policy Attached**
 You can create a basic iam role with Managed Policy Attached
 The iam_managed_policy_arns input param allows an array with one or more managed policies
 ```
@@ -58,7 +58,7 @@ inputs = {
 }
 ```
 
-2. Role With Inline policy 
+2. **Role With Inline policy** 
 You can create a Iam Role with your own inline policy
 
     2.1 Create a new policy file (example: mypolicy.json)
@@ -99,7 +99,7 @@ You can create a Iam Role with your own inline policy
     }
     ```
 
-3. Role With Trusted relationship policy
+3. **Role With Trusted relationship policy**
 Trust relationship – This policy defines which principals can assume the role, 
 and under which conditions. This is sometimes referred to as a resource-based policy 
 for the IAM role. We’ll refer to this policy simply as the ‘trust policy’. 

--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -79,6 +79,7 @@ You can create a Iam Role with your own inline policy
         ]
     }
     ```
+    2.2 Consume the module sending as parameter the previous file with its respective parameters. 
     ```
     iam_name                  = local.iam_rolename
     iam_description           = local.iam_description
@@ -113,6 +114,7 @@ for the IAM role. We’ll refer to this policy simply as the ‘trust policy’.
             ]
         }
     ```
+    3.2 Consume the module sending as parameter the previous file with its respective parameters.
     ```
     iam_name                  = local.iam_rolename
     iam_description           = local.iam_description

--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -57,83 +57,84 @@ inputs = {
   tags                      = local.tags
 }
 ```
+
 2. Role With Inline policy 
 You can create a Iam Role with your own inline policy
 
-2.1 Create a new policy file (example: mypolicy.json)
-```
-{
-    "Id": "ExamplePolicy",
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Sid": "AllowSSLRequestsOnly",
-        "Action": "s3:*",
-        "Effect": "Deny",
-        "Resource": [
-          "arn:aws:s3:::${bucket_name}",
-          "arn:aws:s3:::${bucket_name}/*"
-        ],
-        "Condition": {
-          "Bool": {
-            "aws:SecureTransport": "false"
-          }
-        },
-        "Principal": "*"
-      }
-    ]
-  }
-```
-```
-# ---------------------------------------------------------------------------------------------------------------------
-# MODULE PARAMETERS
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-# ---------------------------------------------------------------------------------------------------------------------
-inputs = {
-  iam_name                  = local.iam_rolename
-  iam_description           = local.iam_description
-  iam_force_detach_policies = true
-  input_iam_inline_policy   = templatefile("mypolicy.json", { bucket_name="my_bucket_name" })
-  tags                      = local.tags
-}
-```
+    2.1 Create a new policy file (example: mypolicy.json)
+    ```
+    {
+        "Id": "ExamplePolicy",
+        "Version": "2012-10-17",
+        "Statement": [
+        {
+            "Sid": "AllowSSLRequestsOnly",
+            "Action": "s3:*",
+            "Effect": "Deny",
+            "Resource": [
+            "arn:aws:s3:::${bucket_name}",
+            "arn:aws:s3:::${bucket_name}/*"
+            ],
+            "Condition": {
+            "Bool": {
+                "aws:SecureTransport": "false"
+            }
+            },
+            "Principal": "*"
+        }
+        ]
+    }
+    ```
+    ```
+    # ---------------------------------------------------------------------------------------------------------------------
+    # MODULE PARAMETERS
+    # These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+    # ---------------------------------------------------------------------------------------------------------------------
+    inputs = {
+    iam_name                  = local.iam_rolename
+    iam_description           = local.iam_description
+    iam_force_detach_policies = true
+    input_iam_inline_policy   = templatefile("mypolicy.json", { bucket_name="my_bucket_name" })
+    tags                      = local.tags
+    }
+    ```
 
 3. Role With Trusted relationship policy
 Trust relationship – This policy defines which principals can assume the role, 
 and under which conditions. This is sometimes referred to as a resource-based policy 
 for the IAM role. We’ll refer to this policy simply as the ‘trust policy’. 
 
-3.1 You can create a file (example: assume_role_policy.json)
-```
-{
+    3.1 You can create a file (example: assume_role_policy.json)
+    ```
     {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "${account_id}"
-                },
-                "Action": "sts:AssumeRole",
-                "Condition": {
-                    "StringEquals": {
-                        "sts:ExternalId": "${external_id}"
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": "${account_id}"
+                    },
+                    "Action": "sts:AssumeRole",
+                    "Condition": {
+                        "StringEquals": {
+                            "sts:ExternalId": "${external_id}"
+                        }
                     }
                 }
-            }
-        ]
+            ]
+        }
+    ```
+    ```
+    # ---------------------------------------------------------------------------------------------------------------------
+    # MODULE PARAMETERS
+    # These are the variables we have to pass in to use the module specified in the terragrunt configuration above
+    # ---------------------------------------------------------------------------------------------------------------------
+    inputs = {
+    iam_name                  = local.iam_rolename
+    iam_description           = local.iam_description
+    iam_force_detach_policies = true
+    iam_assume_role_policy    = templatefile("assume_role_policy.json", { account_id = local.account_id, external_id = local.iam_external_id})
+    tags                      = local.tags
     }
-```
-```
-# ---------------------------------------------------------------------------------------------------------------------
-# MODULE PARAMETERS
-# These are the variables we have to pass in to use the module specified in the terragrunt configuration above
-# ---------------------------------------------------------------------------------------------------------------------
-inputs = {
-  iam_name                  = local.iam_rolename
-  iam_description           = local.iam_description
-  iam_force_detach_policies = true
-  iam_assume_role_policy    = templatefile("assume_role_policy.json", { account_id = local.account_id, external_id = local.iam_external_id})
-  tags                      = local.tags
-}
-```
+    ```

--- a/terraform-modules/aws/iam/generic/README.md
+++ b/terraform-modules/aws/iam/generic/README.md
@@ -22,11 +22,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_iam_assume_role_policy"></a> [iam\_assume\_role\_policy](#input\_iam\_assume\_role\_policy) | Json to create assume\_role\_policy in line | `string` | `"{}"` | no |
 | <a name="input_iam_description"></a> [iam\_description](#input\_iam\_description) | (Optional) Description of the role. | `string` | `"New Role created from ManagedKube Module"` | no |
 | <a name="input_iam_force_detach_policies"></a> [iam\_force\_detach\_policies](#input\_iam\_force\_detach\_policies) | (Optional) Whether to force detaching any policies the role has before destroying it | `bool` | `false` | no |
 | <a name="input_iam_inline_policy"></a> [iam\_inline\_policy](#input\_iam\_inline\_policy) | Json to create policy in line | `string` | `"{}"` | no |
 | <a name="input_iam_managed_policy_arns"></a> [iam\_managed\_policy\_arns](#input\_iam\_managed\_policy\_arns) | List of arn policies to attached | `list(string)` | `[]` | no |
-| <a name="input_iam_max_session_duration"></a> [iam\_max\_session\_duration](#input\_iam\_max\_session\_duration) | (Optional) Maximum session duration (in seconds) that you want to set for the specified role his setting can have a value from 1 hour to 12 hours. | `number` | `60` | no |
+| <a name="input_iam_max_session_duration"></a> [iam\_max\_session\_duration](#input\_iam\_max\_session\_duration) | (Optional) Maximum session duration (in seconds) that you want to set for the specified role his setting can have a value from 1 hour to 12 hours. | `number` | `3600` | no |
 | <a name="input_iam_name"></a> [iam\_name](#input\_iam\_name) | Friendly name of the role | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Key-value mapping of tags for the IAM role. If configured with a provider | `map(any)` | n/a | yes |
 

--- a/terraform-modules/aws/iam/generic/main.tf
+++ b/terraform-modules/aws/iam/generic/main.tf
@@ -1,0 +1,9 @@
+resource "aws_iam_role" "this" {
+  name                  = var.iam_name  
+  description           = var.iam_description
+  force_detach_policies = var.iam_force_detach_policies
+  max_session_duration  = var.iam_max_session_duration
+  inline_policy         = var.iam_inline_policy
+  managed_policy_arns   = var.iam_managed_policy_arns
+  tags                  = var.tags
+}

--- a/terraform-modules/aws/iam/generic/main.tf
+++ b/terraform-modules/aws/iam/generic/main.tf
@@ -3,7 +3,13 @@ resource "aws_iam_role" "this" {
   description           = var.iam_description
   force_detach_policies = var.iam_force_detach_policies
   max_session_duration  = var.iam_max_session_duration
-  inline_policy         = var.iam_inline_policy
+  
+  
+  inline_policy {
+    name   = var.iam_name 
+    policy = var.iam_inline_policy
+  }
+  
   managed_policy_arns   = var.iam_managed_policy_arns
   assume_role_policy    = var.iam_assume_role_policy
   tags                  = var.tags

--- a/terraform-modules/aws/iam/generic/main.tf
+++ b/terraform-modules/aws/iam/generic/main.tf
@@ -5,5 +5,6 @@ resource "aws_iam_role" "this" {
   max_session_duration  = var.iam_max_session_duration
   inline_policy         = var.iam_inline_policy
   managed_policy_arns   = var.iam_managed_policy_arns
+  assume_role_policy    = var.iam_assume_role_policy
   tags                  = var.tags
 }

--- a/terraform-modules/aws/iam/generic/outputs.tf
+++ b/terraform-modules/aws/iam/generic/outputs.tf
@@ -1,0 +1,4 @@
+output "iam_arn" {
+  description = "Amazon Resource Name (ARN) specifying the role."
+  value       = aws_iam_role.this.arn
+}

--- a/terraform-modules/aws/iam/generic/variables.tf
+++ b/terraform-modules/aws/iam/generic/variables.tf
@@ -1,0 +1,50 @@
+variable "iam_name" {
+  type        = string
+  description = "Friendly name of the role"
+}
+
+variable "iam_description" {
+  type        = string
+  default     = "New Role created from ManagedKube Module"
+  description = "(Optional) Description of the role."
+}
+
+variable "iam_force_detach_policies" {
+  type        = bool
+  default     = false
+  description = "(Optional) Whether to force detaching any policies the role has before destroying it"
+}
+
+variable "iam_max_session_duration" {
+  type        = number
+  default     = 60
+  description = "(Optional) Maximum session duration (in seconds) that you want to set for the specified role his setting can have a value from 1 hour to 12 hours."
+}
+
+
+
+#Permission section-----------------------------------------
+variable "iam_inline_policy" {
+  type        = string
+  description = "Json to create policy in line"
+  default     = "{}"
+}
+
+variable "iam_managed_policy_arns" {
+  type        = list(string)
+  description = "List of arn policies to attached"
+  default     = []
+}
+#End of Permission section----------------------------------
+
+
+#Trust relationship section---------------------------------
+
+
+#End Trust relationship section-----------------------------
+
+
+variable "tags" {
+  type = map(any)
+  description = "Key-value mapping of tags for the IAM role. If configured with a provider"
+}

--- a/terraform-modules/aws/iam/generic/variables.tf
+++ b/terraform-modules/aws/iam/generic/variables.tf
@@ -17,7 +17,7 @@ variable iam_force_detach_policies {
 
 variable iam_max_session_duration {
   type        = number
-  default     = 60
+  default     = 3600
   description = "(Optional) Maximum session duration (in seconds) that you want to set for the specified role his setting can have a value from 1 hour to 12 hours."
 }
 

--- a/terraform-modules/aws/iam/generic/variables.tf
+++ b/terraform-modules/aws/iam/generic/variables.tf
@@ -1,21 +1,21 @@
-variable "iam_name" {
+variable iam_name {
   type        = string
   description = "Friendly name of the role"
 }
 
-variable "iam_description" {
+variable iam_description {
   type        = string
   default     = "New Role created from ManagedKube Module"
   description = "(Optional) Description of the role."
 }
 
-variable "iam_force_detach_policies" {
+variable iam_force_detach_policies {
   type        = bool
   default     = false
   description = "(Optional) Whether to force detaching any policies the role has before destroying it"
 }
 
-variable "iam_max_session_duration" {
+variable iam_max_session_duration {
   type        = number
   default     = 60
   description = "(Optional) Maximum session duration (in seconds) that you want to set for the specified role his setting can have a value from 1 hour to 12 hours."
@@ -24,13 +24,13 @@ variable "iam_max_session_duration" {
 
 
 #Permission section-----------------------------------------
-variable "iam_inline_policy" {
+variable iam_inline_policy {
   type        = string
   description = "Json to create policy in line"
   default     = "{}"
 }
 
-variable "iam_managed_policy_arns" {
+variable iam_managed_policy_arns {
   type        = list(string)
   description = "List of arn policies to attached"
   default     = []
@@ -39,7 +39,7 @@ variable "iam_managed_policy_arns" {
 
 
 #Trust relationship section---------------------------------
-variable "iam_assume_role_policy " {
+variable iam_assume_role_policy {
   type        = string
   description = "Json to create assume_role_policy in line"
   default     = "{}"
@@ -47,7 +47,7 @@ variable "iam_assume_role_policy " {
 #End Trust relationship section-----------------------------
 
 
-variable "tags" {
+variable tags {
   type = map(any)
   description = "Key-value mapping of tags for the IAM role. If configured with a provider"
 }

--- a/terraform-modules/aws/iam/generic/variables.tf
+++ b/terraform-modules/aws/iam/generic/variables.tf
@@ -27,7 +27,7 @@ variable iam_max_session_duration {
 variable iam_inline_policy {
   type        = string
   description = "Json to create policy in line"
-  default     = "{}"
+  default     = null
 }
 
 variable iam_managed_policy_arns {

--- a/terraform-modules/aws/iam/generic/variables.tf
+++ b/terraform-modules/aws/iam/generic/variables.tf
@@ -39,8 +39,11 @@ variable "iam_managed_policy_arns" {
 
 
 #Trust relationship section---------------------------------
-
-
+variable "iam_assume_role_policy " {
+  type        = string
+  description = "Json to create assume_role_policy in line"
+  default     = "{}"
+}
 #End Trust relationship section-----------------------------
 
 

--- a/terraform-modules/aws/iam/generic/variables.tf
+++ b/terraform-modules/aws/iam/generic/variables.tf
@@ -27,7 +27,7 @@ variable iam_max_session_duration {
 variable iam_inline_policy {
   type        = string
   description = "Json to create policy in line"
-  default     = null
+  default     = "{}"
 }
 
 variable iam_managed_policy_arns {


### PR DESCRIPTION
### **Feat**: Add a new module for create generic IAM Role
The IAM role is a important aws component regards to security; We din't have a module to create IAM Role in a generic way, We only have modules to IAM with specific task like pod assumble role or pipelines stuffs, the currently module is trying to be generic.

### **Module IAM's Scopes**: 
- force detaching any policies the role has before destroying it
- able to set maximum session duration
- 1 Inline policy
- 1 or N managed policies Arns
- 1 Assumed policy
- Tags for identifying the resource

### **Inputs and outputs**
## Inputs

| Name | Description | Type | Default | Required |
|------|-------------|------|---------|:--------:|
| <a name="input_iam_assume_role_policy"></a> [iam\_assume\_role\_policy](#input\_iam\_assume\_role\_policy) | Json to create assume\_role\_policy in line | `string` | `"{}"` | no |
| <a name="input_iam_description"></a> [iam\_description](#input\_iam\_description) | (Optional) Description of the role. | `string` | `"New Role created from ManagedKube Module"` | no |
| <a name="input_iam_force_detach_policies"></a> [iam\_force\_detach\_policies](#input\_iam\_force\_detach\_policies) | (Optional) Whether to force detaching any policies the role has before destroying it | `bool` | `false` | no |
| <a name="input_iam_inline_policy"></a> [iam\_inline\_policy](#input\_iam\_inline\_policy) | Json to create policy in line | `string` | `"{}"` | no |
| <a name="input_iam_managed_policy_arns"></a> [iam\_managed\_policy\_arns](#input\_iam\_managed\_policy\_arns) | List of arn policies to attached | `list(string)` | `[]` | no |
| <a name="input_iam_max_session_duration"></a> [iam\_max\_session\_duration](#input\_iam\_max\_session\_duration) | (Optional) Maximum session duration (in seconds) that you want to set for the specified role his setting can have a value from 1 hour to 12 hours. | `number` | `3600` | no |
| <a name="input_iam_name"></a> [iam\_name](#input\_iam\_name) | Friendly name of the role | `string` | n/a | yes |
| <a name="input_tags"></a> [tags](#input\_tags) | Key-value mapping of tags for the IAM role. If configured with a provider | `map(any)` | n/a | yes |

## Outputs

| Name | Description |
|------|-------------|
| <a name="output_iam_arn"></a> [iam\_arn](#output\_iam\_arn) | Amazon Resource Name (ARN) specifying the role. |


### **Test cases**
1. Input values
  ```
iam_name                  = local.iam_rolename
  iam_description           = local.iam_description
  iam_force_detach_policies = true
  iam_managed_policy_arns   = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
  iam_assume_role_policy    = templatefile("assume_role_policy.json", { tenable_account_id = local.tenable_account_id, external_id = local.iam_external_id})
  iam_inline_policy         = templatefile("prowler-additions-plus-s3-policy.json", {})
  tags                      = local.tags
```

2. Terraform Apply Log
```
aws-vault exec exact-ops -- terragrunt apply
Acquiring state lock. This may take a few moments...

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_iam_role.this will be created
  + resource "aws_iam_role" "this" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Condition = {
                          + StringEquals = {
                              + sts:ExternalId = "xxxxxxxxxx"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::xxxxxxxx:root"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + description           = "x2-ops-tenable-scan: Specific read-only role for tenable scans in aws account"
      + force_detach_policies = true
      + id                    = (known after apply)
      + managed_policy_arns   = [
          + "arn:aws:iam::aws:policy/ReadOnlyAccess",
        ]
      + max_session_duration  = 3600
      + name                  = "x2-ops-tenable-scan"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags                  = {
          + "ops_env"              = "ops"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "ops/us-west-2/ops/p2a/0301-iam-extra-roles/tenable-scan"
        }
      + tags_all              = {
          + "ops_env"              = "ops"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "ops/us-west-2/ops/p2a/0301-iam-extra-roles/tenable-scan"
        }
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = "x2-ops-tenable-scan"
          + policy = jsonencode(
                {
                  + Statement = [
                      + {
                          + Action   = [
                              + "s3:ListBucket",
                            ]
                          + Effect   = "Allow"
                          + Resource = [
                              + "arn:aws:s3:::testing",
                            ]
                        },
                      + {
                          + Action   = [
                              + "s3:PutObject",
                              + "s3:GetObject",
                              + "s3:DeleteObject",
                              + "s3:PutObjectAcl",
                            ]
                          + Effect   = "Allow"
                          + Resource = [
                              + "arn:aws:s3:::testing/*",
                            ]
                        },
                      + {
                          + Action   = [
                              + "ds:Get*",
                              + "ds:Describe*",
                              + "ds:List*",
                              + "ec2:GetEbsEncryptionByDefault",
                              + "ecr:Describe*",
                              + "elasticfilesystem:DescribeBackupPolicy",
                              + "glue:GetConnections",
                              + "glue:GetSecurityConfiguration",
                              + "glue:SearchTables",
                              + "lambda:GetFunction",
                              + "s3:GetAccountPublicAccessBlock",
                              + "shield:DescribeProtection",
                              + "shield:GetSubscriptionState",
                              + "ssm:GetDocument",
                              + "support:Describe*",
                              + "tag:GetTagKeys",
                            ]
                          + Effect   = "Allow"
                          + Resource = "*"
                          + Sid      = "AllowMoreReadForProwler"
                        },
                      + {
                          + Action   = [
                              + "apigateway:GET",
                            ]
                          + Effect   = "Allow"
                          + Resource = [
                              + "arn:aws:apigateway:*::/restapis/*",
                            ]
                        },
                    ]
                  + Version   = "2012-10-17"
                }
            )
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + iam_arn = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_iam_role.this: Creating...
aws_iam_role.this: Creation complete after 2s [id=x2-ops-tenable-scan]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
Releasing state lock. This may take a few moments...

Outputs:

iam_arn = "arn:aws:iam::xxxxxxx:role/x2-ops-tenable-scan"
```

3. AWS Console Evidence
![Screen Shot 2022-08-23 at 09 56 27](https://user-images.githubusercontent.com/19688747/186205193-747220a0-9936-49c9-a1e1-24ba087af676.png)
![Screen Shot 2022-08-23 at 09 57 33](https://user-images.githubusercontent.com/19688747/186205458-f639fe32-efda-4e57-b4ce-614ced36efd2.png)
![Screen Shot 2022-08-23 at 09 59 48](https://user-images.githubusercontent.com/19688747/186205984-108d9e56-c4d4-4b0b-aae2-148c8400634f.png)

