### PR TITLE
fixed helm api version

### DIFF
--- a/terraform-environments/aws/terragrunt-dev/provider_k8s_helm_for_eks.template.hcl
+++ b/terraform-environments/aws/terragrunt-dev/provider_k8s_helm_for_eks.template.hcl
@@ -25,7 +25,7 @@ provider "helm" {
     # avoid this issue, we use an exec-based plugin here to fetch an up-to-date token. Note that this code requires the
     # kubergrunt binary to be installed and on your PATH.
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       command     = "${kubergrunt_exec}"
       args        = ["eks", "token", "--cluster-id", "${eks_cluster_name}"]
     }


### PR DESCRIPTION
The Helm provider is failing to deploy software packages in Kubernetes with the deprecated api_version

FIX: Pipelines are failing with the `api_version = "client.authentication.k8s.io/v1alpha1"`

updated to `api_version = "client.authentication.k8s.io/v1beta1"` 

in order to fix this issue we need to update the api version: https://github.com/ManagedKube/kubernetes-ops/blob/main/terraform-environments/aws/terragrunt-dev/provider_k8s_helm_for_eks.template.hcl#L28 with
this updated helm version  https://registry.terraform.io/providers/hashicorp/helm/latest/docs#exec-plugins

