### PR TITLE
EKS 1.23 cis driver compatibility

### DIFF
--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -31,11 +31,54 @@ resource "aws_kms_key" "eks" {
   tags        = var.tags
 }
 
-
 module "kms_cloudwatch_log_group" {
   source                  = "github.com/ManagedKube/kubernetes-ops.git//terraform-modules/aws/kms/cloudwatch_log_group?ref=v2.0.37"
   log_group_name          = "/aws/eks/${var.cluster_name}/cluster"
   tags                    = var.tags
+}
+
+//EKS 1.23
+/* It needs Amazon EBS CSI driver in order to mount volume. 
+https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+ebs csi driver is available since 1.14 so it shouldn't impact in previous versions
+that it's using this module.
+https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/
+*/
+
+resource "aws_eks_addon" "csi_driver" {
+  cluster_name             = module.eks.cluster_id
+  addon_name               = "aws-ebs-csi-driver"
+  addon_version            = "v1.11.4-eksbuild.1"
+  service_account_role_arn = aws_iam_role.eks_ebs_csi_driver.arn
+}
+
+data "aws_iam_policy_document" "csi" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+
+    principals {
+      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+      type        = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "eks_ebs_csi_driver" {
+  assume_role_policy = data.aws_iam_policy_document.csi.json
+  name               = "eks-ebs-csi-driver"
+}
+
+resource "aws_iam_role_policy_attachment" "amazon_ebs_csi_driver" {
+  role       = aws_iam_role.eks_ebs_csi_driver.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 }
 
 

--- a/terraform-modules/aws/eks/main.tf
+++ b/terraform-modules/aws/eks/main.tf
@@ -60,12 +60,12 @@ data "aws_iam_policy_document" "csi" {
 
     condition {
       test     = "StringEquals"
-      variable = "${replace(aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub"
+      variable = "${replace(module.eks.oidc_provider, "https://", "")}:sub"
       values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
     }
 
     principals {
-      identifiers = [aws_iam_openid_connect_provider.eks.arn]
+      identifiers = [module.eks.oidc_provider_arn]
       type        = "Federated"
     }
   }

--- a/terraform-modules/aws/eks/variables.tf
+++ b/terraform-modules/aws/eks/variables.tf
@@ -27,7 +27,7 @@ variable "cluster_name" {
 }
 
 variable "cluster_version" {
-  default = "1.21"
+  default = "1.23"
 }
 
 variable "enable_irsa" {


### PR DESCRIPTION
# Description
We upgraded to eks 1.23 recently but we have an issue regards to volumens
error
```
Warning  FailedMount         31m (x5 over 63m)    kubelet                  Unable to attach or mount volumes: unmounted volumes=[prometheus-kube-prometheus-stack-prometheus-db], unattached volumes=[prometheus-kube-prometheus-stack-prometheus-db web-config config config-out prometheus-kube-prometheus-stack-prometheus-rulefiles-0 kube-api-access-4dcz8 tls-assets]: timed out waiting for the condition
  Warning  FailedMount         27m (x2 over 38m)    kubelet                  Unable to attach or mount volumes: unmounted volumes=[prometheus-kube-prometheus-stack-prometheus-db], unattached volumes=[config config-out prometheus-kube-prometheus-stack-prometheus-rulefiles-0 kube-api-access-4dcz8 tls-assets prometheus-kube-prometheus-stack-prometheus-db web-config]: timed out waiting for the condition
  Warning  FailedMount         18m (x3 over 58m)    kubelet                  Unable to attach or mount volumes: unmounted volumes=[prometheus-kube-prometheus-stack-prometheus-db], unattached volumes=[tls-assets prometheus-kube-prometheus-stack-prometheus-db web-config config config-out prometheus-kube-prometheus-stack-prometheus-rulefiles-0 kube-api-access-4dcz8]: timed out waiting for the condition
  Warning  FailedMount         11m (x5 over 61m)    kubelet                  Unable to attach or mount volumes: unmounted volumes=[prometheus-kube-prometheus-stack-prometheus-db], unattached volumes=[kube-api-access-4dcz8 tls-assets prometheus-kube-prometheus-stack-prometheus-db web-config config config-out prometheus-kube-prometheus-stack-prometheus-rulefiles-0]: timed out waiting for the condition
  Warning  FailedMount         9m9s (x3 over 45m)   kubelet                  Unable to attach or mount volumes: unmounted volumes=[prometheus-kube-prometheus-stack-prometheus-db], unattached volumes=[config-out prometheus-kube-prometheus-stack-prometheus-rulefiles-0 kube-api-access-4dcz8 tls-assets prometheus-kube-prometheus-stack-prometheus-db web-config config]: timed out waiting for the condition
  Warning  FailedMount         4m38s (x5 over 47m)  kubelet                  Unable to attach or mount volumes: unmounted volumes=[prometheus-kube-prometheus-stack-prometheus-db], unattached volumes=[web-config config config-out prometheus-kube-prometheus-stack-prometheus-rulefiles-0 kube-api-access-4dcz8 tls-assets prometheus-kube-prometheus-stack-prometheus-db]: timed out waiting for the condition
  Warning  FailedAttachVolume  59s (x20 over 63m)   attachdetach-controller  AttachVolume.Attach failed for volume "pvc-5318da06-7ff4-4d1c-9d2e-9411fd12179c" : Attach timeout for volume vol-00b6a113c17b0e855
  Warning  FailedMount         5s (x6 over 52m)     kubelet                  Unable to attach or mount volumes: unmounted volumes=[prometheus-kube-prometheus-stack-prometheus-db], unattached volumes=[prometheus-kube-prometheus-stack-prometheus-rulefiles-0 kube-api-access-4dcz8 tls-assets prometheus-kube-prometheus-stack-prometheus-db web-config config config-out]: timed out waiting for the condition
```

that error is because in eks 1.23 is necesary to install AWS CIS EBS Driver to handle PV and PVC

# What does this pr do?
- Install CIS driver as addon. 
- Associate a role with the right policy to handle volumenes inside the cluster.

# Breaking changes?
No, due CIS driver is available from 1.14 version but until eks 1.23 is mandatory.

# Docs
https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

> The feature translates in-tree APIs to equivalent CSI APIs and delegates operations to a replacement CSI driver. With this feature, if you use existing StorageClass, PersistentVolume, and PersistentVolumeClaim objects that belong to these workloads, there likely won't be any noticeable change. The feature enables Kubernetes to delegate all storage management operations from the in-tree plugin to the CSI driver. If you use Amazon EBS volumes in an existing cluster, install the Amazon EBS CSI driver in your cluster before you update your cluster to version 1.23. If you don't install the driver before updating an existing cluster, interruptions to your workloads might occur. If you plan to deploy workloads that use Amazon EBS volumes in a new 1.23 cluster, install the [Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) in your cluster before deploying the workloads your cluster. For instructions on how to install the Amazon EBS CSI driver on your cluster, see Amazon EBS CSI driver. For frequently asked questions about the migration feature, see [Amazon EBS CSI migration frequently asked questions](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi-migration-faq.html).

# Evidence of proof
https://github.com/exact-payments/gruntwork-infrastructure-live/actions/runs/4145523326/jobs/7170001530#step:16:32
```
aws-vault exec exact-ops -- terragrunt apply 
Acquiring state lock. This may take a few moments...
here refreshing state.....
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # aws_eks_addon.csi_driver will be created
  + resource "aws_eks_addon" "csi_driver" {
      + addon_name               = "aws-ebs-csi-driver"
      + addon_version            = "v1.11.4-eksbuild.1"
      + arn                      = (known after apply)
      + cluster_name             = "ops"
      + configuration_values     = (known after apply)
      + created_at               = (known after apply)
      + id                       = (known after apply)
      + modified_at              = (known after apply)
      + service_account_role_arn = (known after apply)
      + tags_all                 = (known after apply)
    }

  # aws_iam_role.eks_ebs_csi_driver will be created
  + resource "aws_iam_role" "eks_ebs_csi_driver" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRoleWithWebIdentity"
                      + Condition = {
                          + StringEquals = {
                              + oidc.eks.us-west-2.amazonaws.com/id/FC8971DCA0E7B36B4E10D3DD8457739B:sub = "system:serviceaccount:kube-system:ebs-csi-controller-sa"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Federated = "arn:aws:iam::xxxxxxxxxxxx:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/FC8971DCA0E7B36B4E10D3DD8457739B"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "eks-ebs-csi-driver"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_iam_role_policy_attachment.amazon_ebs_csi_driver will be created
  + resource "aws_iam_role_policy_attachment" "amazon_ebs_csi_driver" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
      + role       = "eks-ebs-csi-driver"
    }

  # module.eks.kubernetes_config_map_v1_data.aws_auth[0] will be updated in-place
  ~ resource "kubernetes_config_map_v1_data" "aws_auth" {
      + field_manager = "Terraform"
        id            = "kube-system/aws-auth"
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 3 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ cluster_platform_version = "eks.9" -> "eks.5"

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_iam_role.eks_ebs_csi_driver: Creating...
module.eks.kubernetes_config_map_v1_data.aws_auth[0]: Modifying... [id=kube-system/aws-auth]
module.eks.kubernetes_config_map_v1_data.aws_auth[0]: Modifications complete after 2s [id=kube-system/aws-auth]
aws_iam_role.eks_ebs_csi_driver: Creation complete after 2s [id=eks-ebs-csi-driver]
aws_iam_role_policy_attachment.amazon_ebs_csi_driver: Creating...
aws_eks_addon.csi_driver: Creating...
aws_iam_role_policy_attachment.amazon_ebs_csi_driver: Creation complete after 0s [id=eks-ebs-csi-driver-20230209202009064900000002]
aws_eks_addon.csi_driver: Still creating... [10s elapsed]
aws_eks_addon.csi_driver: Still creating... [20s elapsed]
aws_eks_addon.csi_driver: Still creating... [30s elapsed]
aws_eks_addon.csi_driver: Still creating... [40s elapsed]
aws_eks_addon.csi_driver: Creation complete after 49s [id=ops:aws-ebs-csi-driver]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 3 added, 1 changed, 0 destroyed.

Outputs:

cluster_arn = "arn:aws:eks:us-west-2:xxxxxxx:cluster/ops"
cluster_certificate_authority_data = "xxxxxxxx"
cluster_endpoint = "https://xxxxxxx.gr7.us-west-2.eks.amazonaws.com"
cluster_iam_role_arn = "arn:aws:iam::xxxxxxxx:role/ops-cluster-20230105221232509200000001"
cluster_id = "ops"
cluster_oidc_issuer_url = "https://oidc.eks.us-west-2.amazonaws.com/id/FC8971DCA0E7B36B4E10D3DD8457739B"
cluster_platform_version = "eks.5"
cluster_primary_security_group_id = "sg-081a416849f18820b"
cluster_security_group_id = "sg-07b6a0fc59f0f2d57"
eks_managed_node_groups_arns = [
  {
    "rolearn" = "arn:aws:iam::476264532441:role/ng1-eks-node-group-20230105214018781800000005"
  },
  {
    "rolearn" = "arn:aws:iam::476264532441:role/webhook-eks-node-group-20230105214018779800000003"
  },
]
environment_name = "ops"
node_security_group_id = "sg-0218c97f5cafa8552"
oidc_provider_arn = "arn:aws:iam::476264532441:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/FC8971DCA0E7B36B4E10D3DD8457739B"
```

Add on
![Screenshot 2023-02-10 at 15 16 45](https://user-images.githubusercontent.com/19688747/218199079-6639c501-f768-4da4-a79d-26073cedf55d.png)

Iam role
![Screenshot 2023-02-10 at 15 17 13](https://user-images.githubusercontent.com/19688747/218199160-edaef491-200a-4e2e-986c-521345749bdf.png)

Policy
![Screenshot 2023-02-10 at 15 17 39](https://user-images.githubusercontent.com/19688747/218199218-8e80304e-3ea5-4eab-bc6a-87bcc0ae6b04.png)



