### PR TITLE
Upgrade cluster autoscaler

### DIFF
--- a/terraform-modules/aws/cluster-autoscaler/main.tf
+++ b/terraform-modules/aws/cluster-autoscaler/main.tf
@@ -77,7 +77,7 @@ module "cluster-autoscaler" {
   repository          = "https://kubernetes.github.io/autoscaler"
   official_chart_name = "cluster-autoscaler"
   user_chart_name     = "cluster-autoscaler"
-  helm_version        = "9.9.2"
+  helm_version        = "9.24.0"
   namespace           = "kube-system"
   helm_values         = data.template_file.helm_values.rendered
 


### PR DESCRIPTION
This PR is to make an upgrade of the cluster autoscaler to the latest version: https://github.com/kubernetes/autoscaler/tree/cluster-autoscaler-chart-9.24.0