### PR TITLE
AWS Security group in managedkube

### DIFF
--- a/terraform-modules/aws/securitygroup/README.md
+++ b/terraform-modules/aws/securitygroup/README.md
@@ -32,6 +32,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_arn"></a> [arn](#output\_arn) | n/a |
-| <a name="output_id"></a> [id](#output\_id) | n/a |
-| <a name="output_name"></a> [name](#output\_name) | n/a |
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the security group. |
+| <a name="output_id"></a> [id](#output\_id) | ID of the security group. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the security group |

--- a/terraform-modules/aws/securitygroup/README.md
+++ b/terraform-modules/aws/securitygroup/README.md
@@ -26,6 +26,7 @@ No modules.
 | <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | A list of egress rules to apply to the security group | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = string<br>    cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | A list of ingress rules to apply to the security group | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = string<br>    cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the security group | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A list of tags | `map(any)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC in which to create the security group | `string` | n/a | yes |
 
 ## Outputs

--- a/terraform-modules/aws/securitygroup/README.md
+++ b/terraform-modules/aws/securitygroup/README.md
@@ -23,8 +23,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_description"></a> [description](#input\_description) | The description of the security group | `string` | n/a | yes |
-| <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | A list of egress rules to apply to the security group | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = string<br>    cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
-| <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | A list of ingress rules to apply to the security group | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = string<br>    cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | A list of egress rules to apply to the security group | <pre>list(object({<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | A list of ingress rules to apply to the security group | <pre>list(object({<br>    description      = string<br>    from_port        = number<br>    to_port          = number<br>    protocol         = string<br>    cidr_blocks      = list(string)<br>    ipv6_cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the security group | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A list of tags | `map(any)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC in which to create the security group | `string` | n/a | yes |

--- a/terraform-modules/aws/securitygroup/README.md
+++ b/terraform-modules/aws/securitygroup/README.md
@@ -1,0 +1,37 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_security_group.sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_description"></a> [description](#input\_description) | The description of the security group | `string` | n/a | yes |
+| <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | A list of egress rules to apply to the security group | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = string<br>    cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | A list of ingress rules to apply to the security group | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    protocol    = string<br>    cidr_blocks = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the security group | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC in which to create the security group | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | n/a |
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |

--- a/terraform-modules/aws/securitygroup/main.tf
+++ b/terraform-modules/aws/securitygroup/main.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group" "sg" {
+  name        = var.name
+  description = var.description
+  vpc_id      = var.vpc_id
+
+  ingress     = var.ingress_rules
+  egress      = var.egress_rules
+}

--- a/terraform-modules/aws/securitygroup/main.tf
+++ b/terraform-modules/aws/securitygroup/main.tf
@@ -3,6 +3,28 @@ resource "aws_security_group" "sg" {
   description = var.description
   vpc_id      = var.vpc_id
 
-  ingress     = var.ingress_rules
-  egress      = var.egress_rules
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+
+    content {
+      description      = ingress.value.description
+      from_port        = ingress.value.from_port
+      to_port          = ingress.value.to_port
+      protocol         = ingress.value.protocol
+      cidr_blocks      = ingress.value.cidr_blocks
+      ipv6_cidr_blocks = ingress.value.ipv6_cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.egress_rules
+
+    content {
+      from_port        = egress.value.from_port
+      to_port          = egress.value.to_port
+      protocol         = egress.value.protocol
+      cidr_blocks      = egress.value.cidr_blocks
+      ipv6_cidr_blocks = egress.value.ipv6_cidr_blocks
+    }
+  }
 }

--- a/terraform-modules/aws/securitygroup/main.tf
+++ b/terraform-modules/aws/securitygroup/main.tf
@@ -27,4 +27,5 @@ resource "aws_security_group" "sg" {
       ipv6_cidr_blocks = egress.value.ipv6_cidr_blocks
     }
   }
+  tags = var.tags
 }

--- a/terraform-modules/aws/securitygroup/outputs.tf
+++ b/terraform-modules/aws/securitygroup/outputs.tf
@@ -1,0 +1,11 @@
+output "id" {
+  value = aws_security_group.sg.id
+}
+
+output "arn" {
+  value = aws_security_group.sg.arn
+}
+
+output "name" {
+  value = aws_security_group.sg.name
+}

--- a/terraform-modules/aws/securitygroup/outputs.tf
+++ b/terraform-modules/aws/securitygroup/outputs.tf
@@ -1,11 +1,14 @@
 output "id" {
   value = aws_security_group.sg.id
+  description = "ID of the security group."
 }
 
 output "arn" {
   value = aws_security_group.sg.arn
+  description = "ARN of the security group."
 }
 
 output "name" {
   value = aws_security_group.sg.name
+  description = "The name of the security group"
 }

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -14,12 +14,12 @@ variable "vpc_id" {
 }
 
 variable "ingress_rules" {
-  type        = list(map(any))
+  type        = list(object)
   description = "A list of ingress rules to apply to the security group"
 }
 
 variable "egress_rules" {
-  type        = list(map(any))
+  type        = list(object)
   description = "A list of egress rules to apply to the security group"
 }
 

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -15,26 +15,30 @@ variable "vpc_id" {
 
 variable "ingress_rules" {
   type = list(object({
-    description = string
-    from_port   = number
-    to_port     = number
-    protocol    = string
-    cidr_blocks = list(string)
+    description      = string
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = list(string)
     ipv6_cidr_blocks = list(string)
-    self        = bool
+    self             = bool
+    prefix_list_ids  = list(string)
+    security_groups  = list(string)
   }))
   description = "A list of ingress rules to apply to the security group"
 }
 
 variable "egress_rules" {
   type = list(object({
-    description = string
-    from_port   = number
-    to_port     = number
-    protocol    = string
-    cidr_blocks = list(string)
+    description      = string
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = list(string)
     ipv6_cidr_blocks = list(string)
-    self        = bool
+    self             = bool
+    prefix_list_ids  = list(string)
+    security_groups  = list(string)
   }))
   description = "A list of egress rules to apply to the security group"
 }

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -14,32 +14,12 @@ variable "vpc_id" {
 }
 
 variable "ingress_rules" {
-  type = list(object({
-    description      = string
-    from_port        = number
-    to_port          = number
-    protocol         = string
-    cidr_blocks      = list(string)
-    ipv6_cidr_blocks = list(string)
-    self             = bool
-    prefix_list_ids  = list(string)
-    security_groups  = list(string)
-  }))
+  type        = list(map(string))
   description = "A list of ingress rules to apply to the security group"
 }
 
 variable "egress_rules" {
-  type = list(object({
-    description      = string
-    from_port        = number
-    to_port          = number
-    protocol         = string
-    cidr_blocks      = list(string)
-    ipv6_cidr_blocks = list(string)
-    self             = bool
-    prefix_list_ids  = list(string)
-    security_groups  = list(string)
-  }))
+  type        = list(map(string))
   description = "A list of egress rules to apply to the security group"
 }
 

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -20,6 +20,7 @@ variable "ingress_rules" {
     to_port     = number
     protocol    = string
     cidr_blocks = list(string)
+    ipv6_cidr_blocks = list(string)
     self        = bool
   }))
   description = "A list of ingress rules to apply to the security group"
@@ -32,6 +33,7 @@ variable "egress_rules" {
     to_port     = number
     protocol    = string
     cidr_blocks = list(string)
+    ipv6_cidr_blocks = list(string)
     self        = bool
   }))
   description = "A list of egress rules to apply to the security group"

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -15,6 +15,7 @@ variable "vpc_id" {
 
 variable "ingress_rules" {
   type = list(object({
+    description = string
     from_port   = number
     to_port     = number
     protocol    = string
@@ -25,6 +26,7 @@ variable "ingress_rules" {
 
 variable "egress_rules" {
   type = list(object({
+    description = string
     from_port   = number
     to_port     = number
     protocol    = string

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -32,3 +32,8 @@ variable "egress_rules" {
   }))
   description = "A list of egress rules to apply to the security group"
 }
+
+variable "tags" {
+    type = map(any)
+    description = "A list of tags"
+}

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -20,6 +20,7 @@ variable "ingress_rules" {
     to_port     = number
     protocol    = string
     cidr_blocks = list(string)
+    self        = bool
   }))
   description = "A list of ingress rules to apply to the security group"
 }
@@ -31,6 +32,7 @@ variable "egress_rules" {
     to_port     = number
     protocol    = string
     cidr_blocks = list(string)
+    self        = bool
   }))
   description = "A list of egress rules to apply to the security group"
 }

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -14,13 +14,26 @@ variable "vpc_id" {
 }
 
 variable "ingress_rules" {
-  type        = list(object)
   description = "A list of ingress rules to apply to the security group"
+  type = list(object({
+    description      = string
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = list(string)
+    ipv6_cidr_blocks = list(string)
+  }))
 }
 
 variable "egress_rules" {
-  type        = list(object)
   description = "A list of egress rules to apply to the security group"
+  type = list(object({
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = list(string)
+    ipv6_cidr_blocks = list(string)
+  }))
 }
 
 variable "tags" {

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  type = string
+  description = "The name of the security group"
+}
+
+variable "description" {
+  type = string
+  description = "The description of the security group"
+}
+
+variable "vpc_id" {
+  type = string
+  description = "The ID of the VPC in which to create the security group"
+}
+
+variable "ingress_rules" {
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+  }))
+  description = "A list of ingress rules to apply to the security group"
+}
+
+variable "egress_rules" {
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+  }))
+  description = "A list of egress rules to apply to the security group"
+}

--- a/terraform-modules/aws/securitygroup/variables.tf
+++ b/terraform-modules/aws/securitygroup/variables.tf
@@ -14,12 +14,12 @@ variable "vpc_id" {
 }
 
 variable "ingress_rules" {
-  type        = list(map(string))
+  type        = list(map(any))
   description = "A list of ingress rules to apply to the security group"
 }
 
 variable "egress_rules" {
-  type        = list(map(string))
+  type        = list(map(any))
   description = "A list of egress rules to apply to the security group"
 }
 


### PR DESCRIPTION
# What
- Create security groups with dynamic egress and ingress rules.

# Test Cases
I am using this branch in https://github.com/exact-payments/gruntwork-infrastructure-live/pull/1523/files#diff-e91895dc3db4c983ccee4507ad3193f15ce0dae981239cefb1d7118e3527312cR12 \

- inputs
```
Inputs = {
  vpc_id        = dependency.vpc.outputs.vpc_id
  name          = local.name
  description   = local.description
  # Rules
  ingress_rules = [
    {
      description      = "Allow SSH to vpc mainly CIDR"
      from_port        = 22
      to_port          = 22
      protocol         = "tcp"
      cidr_blocks      = ["${local.vpc_cidr}"]
      ipv6_cidr_blocks = []
    },
    {
      description      = "Allow SSH to vpc secondary CIDR"
      from_port        = 443
      to_port          = 443
      protocol         = "tcp"
      cidr_blocks      = ["${local.vpc_secondary_cidr}"]
      ipv6_cidr_blocks = []
    }
  ]

  egress_rules = [
    {
      description      = "Allow All egress traffic"
      from_port        = 0
      to_port          = 0
      protocol         = "-1"
      cidr_blocks      = ["0.0.0.0/0"]
      ipv6_cidr_blocks = []
    }
  ]
  tags        = local.tags
}
```
- how looks like the sg in aws
<img width="1271" alt="Screenshot 2023-03-01 at 14 22 52" src="https://user-images.githubusercontent.com/19688747/222256974-0b1c204e-e6e7-4af5-bbdc-57813eb3b9ea.png">

<img width="1254" alt="Screenshot 2023-03-01 at 14 23 07" src="https://user-images.githubusercontent.com/19688747/222257031-d5906cd8-9a0c-4b1e-8131-9cbf4b3b302f.png">

<img width="1273" alt="Screenshot 2023-03-01 at 14 30 53" src="https://user-images.githubusercontent.com/19688747/222258422-d39bfe42-a473-410c-97d7-f5e921fc6486.png">


- apply
```
root@cc6aa29f5343:/workspaces/gruntwork-infrastructure-live/ops/us-west-2/ops/p2a/3000-data-platform/3018-sftp-vpc-endpoint-sg# terragrunt apply
Acquiring state lock. This may take a few moments...

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_security_group.sg will be created
  + resource "aws_security_group" "sg" {
      + arn                    = (known after apply)
      + description            = "This is a security group in order to allow traffic from dataplatform vpc"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "10.117.192.0/18",
                ]
              + description      = "Allow SSH to vpc mainly CIDR"
              + from_port        = 22
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 22
            },
          + {
              + cidr_blocks      = [
                  + "10.137.0.0/16",
                ]
              + description      = "Allow SSH to vpc secondary CIDR"
              + from_port        = 443
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 443
            },
        ]
      + name                   = "ops-sg-sftp-vpc-endpoint"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags_all               = (known after apply)
      + vpc_id                 = "vpc-0254921a46bca1455"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + arn  = (known after apply)
  + id   = (known after apply)
  + name = "ops-sg-sftp-vpc-endpoint"

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

aws_security_group.sg: Creating...
aws_security_group.sg: Creation complete after 5s [id=sg-0c9fafb25d1656f09]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

arn = "arn:aws:ec2:us-west-2:476264532441:security-group/sg-0c9fafb25d1656f09"
id = "sg-0c9fafb25d1656f09"
name = "ops-sg-sftp-vpc-endpoint"
```

