### PR TITLE
Update Airflow Module

### DIFF
--- a/terraform-modules/aws/airflow/main.tf
+++ b/terraform-modules/aws/airflow/main.tf
@@ -17,7 +17,7 @@ resource "aws_s3_bucket_acl" "this" {
 
 # Using the default AWS KMS master key
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
-  bucket = aws_s3_bucket.airflow.arn
+  bucket = aws_s3_bucket.airflow.bucket
 
   rule {
     apply_server_side_encryption_by_default {
@@ -41,7 +41,7 @@ resource "aws_mwaa_environment" "this" {
   environment_class  = var.environment_class
   max_workers        = var.max_workers
   min_workers        = var.min_workers
-  source_bucket_arn  = aws_s3_bucket.mwaa.arn
+  source_bucket_arn  = aws_s3_bucket.airflow.arn
   dag_s3_path        = var.dag_s3_path
   execution_role_arn = module.iam_assumable_role_admin.iam_role_arn
   webserver_access_mode = var.webserver_access_mode

--- a/terraform-modules/aws/airflow/variables.tf
+++ b/terraform-modules/aws/airflow/variables.tf
@@ -102,3 +102,14 @@ variable "worker_log_level" {
   default     = "INFO"
   description = "The log level: INFO | WARNING | ERROR | CRITICAL"
 }
+
+variable "webserver_access_mode" {
+  description = "(Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE_ONLY (default) and PUBLIC_ONLY"
+  type        = string
+  default     = "PRIVATE_ONLY"
+
+  validation {
+    condition     = contains(["PRIVATE_ONLY", "PUBLIC_ONLY"], var.webserver_access_mode)
+    error_message = "Invalid input, options: \"PRIVATE_ONLY\", \"PUBLIC_ONLY\"."
+  }
+}


### PR DESCRIPTION
### This PR includes updates to the Terraform module for deploying an Airflow environment on AWS. The following changes were made:

- The webserver_access_mode variable was added to the aws_mwaa_environment resource block, allowing for more control over the web server's access mode.

- The IAM role module was updated to the latest version (5.11.2) to incorporate bug fixes and other improvements.

### An Amazon S3 bucket with versioning, server-side encryption, and access control policies

- The aws_s3_bucket resource creates an S3 bucket, which is used as the source for the MWAA environment. The aws_s3_bucket_versioning resource enables versioning for the S3 bucket. The aws_s3_bucket_acl resource sets the bucket ACL to private, which means that only authorized users can access the bucket.

- The aws_s3_bucket_server_side_encryption_configuration resource enables server-side encryption for the S3 bucket. The aws_s3_bucket_public_access_block resource blocks public access to the S3 bucket.

### **Tested this module with the latest Airflow version**

### Test Inputs 

```
inputs = {
  airflow_name       = "airflow-${local.account_name}"
  aws_region         = local.aws_region
  vpc_id             = dependency.vpc.outputs.vpc_id
  subnet_ids         = [dependency.vpc.outputs.private_subnets[0], dependency.vpc.outputs.private_subnets[1] ]
  airflow_version    = "2.4.3"
  webserver_access_mode = "PUBLIC_ONLY"
  environment_class  = "mw1.small"
  max_workers        = 10
  min_workers        = 1
  source_bucket_name = local.source_bucket_name
  dag_s3_path        = "dags/"
  tags               = local.tags
}
```

### TF APPLY

```
aws_s3_bucket.airflow: Creation complete after 2s [id=airflow-s3-ops]
aws_s3_bucket_acl.this: Creating...
aws_s3_bucket_versioning.this: Creating...
aws_s3_bucket_public_access_block.this: Creating...
aws_s3_bucket_server_side_encryption_configuration.this: Creating...
aws_mwaa_environment.this: Creating...
aws_s3_bucket_acl.this: Creation complete after 1s [id=airflow-s3-ops,private]
aws_s3_bucket_server_side_encryption_configuration.this: Creation complete after 1s [id=airflow-s3-ops]
aws_s3_bucket_public_access_block.this: Creation complete after 2s [id=airflow-s3-ops]
aws_s3_bucket_versioning.this: Creation complete after 2s [id=airflow-s3-ops]
aws_mwaa_environment.this: Still creating... [14m51s elapsed]
aws_mwaa_environment.this: Still creating... [15m1s elapsed]
aws_mwaa_environment.this: Still creating... [15m11s elapsed]
aws_mwaa_environment.this: Still creating... [15m21s elapsed]
aws_mwaa_environment.this: Still creating... [15m31s elapsed]
aws_mwaa_environment.this: Still creating... [15m41s elapsed]
aws_mwaa_environment.this: Still creating... [15m51s elapsed]
aws_mwaa_environment.this: Still creating... [16m1s elapsed]
aws_mwaa_environment.this: Still creating... [16m11s elapsed]
aws_mwaa_environment.this: Still creating... [16m21s elapsed]
aws_mwaa_environment.this: Still creating... [16m31s elapsed]
aws_mwaa_environment.this: Still creating... [16m41s elapsed]
aws_mwaa_environment.this: Still creating... [16m51s elapsed]
aws_mwaa_environment.this: Still creating... [17m1s elapsed]
aws_mwaa_environment.this: Still creating... [17m11s elapsed]
aws_mwaa_environment.this: Still creating... [17m21s elapsed]
aws_mwaa_environment.this: Still creating... [17m31s elapsed]
aws_mwaa_environment.this: Still creating... [17m41s elapsed]
aws_mwaa_environment.this: Still creating... [17m51s elapsed]
aws_mwaa_environment.this: Still creating... [18m1s elapsed]
aws_mwaa_environment.this: Still creating... [18m11s elapsed]
aws_mwaa_environment.this: Still creating... [18m21s elapsed]
aws_mwaa_environment.this: Still creating... [18m31s elapsed]
aws_mwaa_environment.this: Still creating... [18m41s elapsed]
aws_mwaa_environment.this: Still creating... [18m51s elapsed]
aws_mwaa_environment.this: Still creating... [19m1s elapsed]
aws_mwaa_environment.this: Still creating... [19m11s elapsed]
aws_mwaa_environment.this: Still creating... [19m21s elapsed]
aws_mwaa_environment.this: Still creating... [19m31s elapsed]
aws_mwaa_environment.this: Still creating... [19m41s elapsed]
aws_mwaa_environment.this: Still creating... [19m51s elapsed]
aws_mwaa_environment.this: Still creating... [20m1s elapsed]
aws_mwaa_environment.this: Still creating... [20m11s elapsed]
aws_mwaa_environment.this: Still creating... [20m21s elapsed]
aws_mwaa_environment.this: Still creating... [20m31s elapsed]
aws_mwaa_environment.this: Still creating... [20m41s elapsed]
aws_mwaa_environment.this: Still creating... [20m51s elapsed]
aws_mwaa_environment.this: Still creating... [21m1s elapsed]
aws_mwaa_environment.this: Still creating... [21m11s elapsed]
aws_mwaa_environment.this: Still creating... [21m21s elapsed]
aws_mwaa_environment.this: Still creating... [21m31s elapsed]
aws_mwaa_environment.this: Still creating... [21m41s elapsed]
aws_mwaa_environment.this: Still creating... [21m51s elapsed]
aws_mwaa_environment.this: Still creating... [22m1s elapsed]
aws_mwaa_environment.this: Still creating... [22m11s elapsed]
aws_mwaa_environment.this: Still creating... [22m21s elapsed]
aws_mwaa_environment.this: Still creating... [22m31s elapsed]
aws_mwaa_environment.this: Still creating... [22m41s elapsed]
aws_mwaa_environment.this: Still creating... [22m51s elapsed]
aws_mwaa_environment.this: Still creating... [23m1s elapsed]
aws_mwaa_environment.this: Still creating... [23m11s elapsed]
aws_mwaa_environment.this: Still creating... [23m21s elapsed]
aws_mwaa_environment.this: Still creating... [23m31s elapsed]
aws_mwaa_environment.this: Still creating... [23m41s elapsed]
aws_mwaa_environment.this: Still creating... [23m51s elapsed]
aws_mwaa_environment.this: Still creating... [24m1s elapsed]
aws_mwaa_environment.this: Still creating... [24m11s elapsed]
aws_mwaa_environment.this: Still creating... [24m21s elapsed]
aws_mwaa_environment.this: Still creating... [24m31s elapsed]
aws_mwaa_environment.this: Still creating... [24m41s elapsed]
aws_mwaa_environment.this: Still creating... [24m51s elapsed]
aws_mwaa_environment.this: Still creating... [25m1s elapsed]
aws_mwaa_environment.this: Still creating... [25m11s elapsed]
aws_mwaa_environment.this: Still creating... [25m21s elapsed]
aws_mwaa_environment.this: Still creating... [25m31s elapsed]
aws_mwaa_environment.this: Still creating... [25m41s elapsed]
aws_mwaa_environment.this: Still creating... [25m51s elapsed]
aws_mwaa_environment.this: Still creating... [26m1s elapsed]
aws_mwaa_environment.this: Still creating... [26m11s elapsed]
aws_mwaa_environment.this: Still creating... [26m21s elapsed]
aws_mwaa_environment.this: Still creating... [26m31s elapsed]
aws_mwaa_environment.this: Still creating... [26m41s elapsed]
aws_mwaa_environment.this: Still creating... [26m51s elapsed]
aws_mwaa_environment.this: Creation complete after 27m1s [id=airflow-ops]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 9 added, 0 changed, 0 destroyed.

Outputs:

arn = "arn:aws:airflow:us-west-2:476264532441:environment/airflow-ops"
webserver_url = "918ae5ac-4bea-4aed-a899-f536d5940a0f-vpce.c8.us-west-2.airflow.amazonaws.com"
```

### AIRFLOW WEBGUI with v2.4.3

<img width="1509" alt="Screen Shot 2023-03-02 at 6 25 55 PM" src="https://user-images.githubusercontent.com/108491140/222586646-3a8d4ec0-16d2-4d56-bee5-746223746cdd.png">


<img width="1506" alt="Screen Shot 2023-03-02 at 6 14 47 PM" src="https://user-images.githubusercontent.com/108491140/222584283-6225fd7a-7598-4496-97ab-b71aefd86b61.png">
