### PR TITLE
Adding New IAM Policy for Cluster Autoscaler

### DIFF
--- a/terraform-modules/aws/cluster-autoscaler/main.tf
+++ b/terraform-modules/aws/cluster-autoscaler/main.tf
@@ -23,7 +23,9 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
       "autoscaling:DescribeTags",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplateVersions",
     ]
 
@@ -38,6 +40,9 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
       "autoscaling:UpdateAutoScalingGroup",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
The worker running the cluster autoscaler needs access to certain resources and actions for new versions and its configuration as suggested here: https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler#additional-configuration

The up-to-date IAM permissions required, is gotten from the cluster autoscaler's AWS Cloudprovider Readme (selecting the tag of the cluster autoscaler image in use): https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-chart-9.24.0/cluster-autoscaler/cloudprovider/aws/README.md

