### PR TITLE
Update qldb module

### DIFF
--- a/terraform-modules/aws/qldb/main.tf
+++ b/terraform-modules/aws/qldb/main.tf
@@ -2,7 +2,6 @@ resource "aws_qldb_ledger" "this" {
   name                = var.name
   permissions_mode    = var.permissions_mode
   deletion_protection = var.deletion_protection
-  kms_key             = var.kms_key
   tags                = var.tags
 
   vpc_configuration {

--- a/terraform-modules/aws/qldb/main.tf
+++ b/terraform-modules/aws/qldb/main.tf
@@ -5,7 +5,7 @@ resource "aws_qldb_ledger" "this" {
   tags                = var.tags
 }
 
-resource "aws_security_group" "this" {
+resource "aws_security_group" "qldb" {
   name        = "qldb-${var.name}"
   description = "qldb security group"
   vpc_id      = var.vpc_id
@@ -25,6 +25,19 @@ resource "aws_security_group" "this" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+
+  tags = var.tags
+}
+
+resource "aws_vpc_endpoint" "qldb" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.us-west-2.qldb.session"
+  vpc_endpoint_type   = "Interface"
+
+  security_group_ids  = [aws_security_group.qldb.id]
+  subnet_ids          = var.subnet_ids
+
+  private_dns_enabled = true
 
   tags = var.tags
 }

--- a/terraform-modules/aws/qldb/main.tf
+++ b/terraform-modules/aws/qldb/main.tf
@@ -10,20 +10,28 @@ resource "aws_security_group" "qldb" {
   description = "qldb security group"
   vpc_id      = var.vpc_id
 
-  ingress {
-    description      = "TLS from VPC"
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+  dynamic "ingress" {
+    for_each = var.ingress_rule
+    content {
+      description      = ingress.value["description"]
+      from_port        = ingress.value["from_port"]
+      to_port          = ingress.value["to_port"]
+      protocol         = ingress.value["protocol"]
+      cidr_blocks      = ingress.value["cidr_blocks"]
+      ipv6_cidr_blocks = ingress.value["ipv6_cidr_blocks"]
+    }
   }
 
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+  dynamic "egress" {
+    for_each = var.egress_rule
+    content {
+      description      = egress.value["description"]
+      from_port        = egress.value["from_port"]
+      to_port          = egress.value["to_port"]
+      protocol         = egress.value["protocol"]
+      cidr_blocks      = egress.value["cidr_blocks"]
+      ipv6_cidr_blocks = egress.value["ipv6_cidr_blocks"]
+    }
   }
 
   tags = var.tags

--- a/terraform-modules/aws/qldb/main.tf
+++ b/terraform-modules/aws/qldb/main.tf
@@ -3,14 +3,10 @@ resource "aws_qldb_ledger" "this" {
   permissions_mode    = var.permissions_mode
   deletion_protection = var.deletion_protection
   tags                = var.tags
-
-  vpc_configuration {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = [aws_security_group.this.id]
-  }
 }
+
 resource "aws_security_group" "this" {
-  name        = var.name
+  name        = "qldb-${var.name}"
   description = "qldb security group"
   vpc_id      = var.vpc_id
 

--- a/terraform-modules/aws/qldb/main.tf
+++ b/terraform-modules/aws/qldb/main.tf
@@ -2,5 +2,34 @@ resource "aws_qldb_ledger" "this" {
   name                = var.name
   permissions_mode    = var.permissions_mode
   deletion_protection = var.deletion_protection
+  kms_key             = var.kms_key
   tags                = var.tags
+
+  vpc_configuration {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = [aws_security_group.this.id]
+  }
+}
+resource "aws_security_group" "this" {
+  name        = var.name
+  description = "qldb security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = var.tags
 }

--- a/terraform-modules/aws/qldb/outputs.tf
+++ b/terraform-modules/aws/qldb/outputs.tf
@@ -5,3 +5,8 @@ output "id" {
 output "arn" {
   value       = aws_qldb_ledger.this.arn
 }
+
+output "vpc_endpoint_id" {
+  value       = aws_vpc_endpoint.qldb.id
+}
+

--- a/terraform-modules/aws/qldb/variables.tf
+++ b/terraform-modules/aws/qldb/variables.tf
@@ -21,3 +21,15 @@ variable "tags" {
   default     = {}
   description = "AWS Tags"
 }
+
+variable "subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "(Required) The private subnet IDs in which the environment should be created. MWAA requires two subnets."
+}
+
+variable "vpc_id" {
+  type        = string
+  default     = ""
+  description = "The vpc ID"
+}

--- a/terraform-modules/aws/qldb/variables.tf
+++ b/terraform-modules/aws/qldb/variables.tf
@@ -39,9 +39,10 @@ variable "ingress_rule" {
   description = "A list of ingress rules"
   default = [
     {
-      description      = "All ports from internal addresses"
-      from_port        = 0
-      to_port          = 65535
+      description      = "TLS from VPC"
+      //Port 443 is commonly used port for secure HTTPS traffic
+      from_port        = 443
+      to_port          = 443
       protocol         = "tcp"
       cidr_blocks      = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
       ipv6_cidr_blocks = []
@@ -54,9 +55,10 @@ variable "egress_rule" {
   description = "A list of egress rules"
   default = [
     {
-      description      = "All ports from internal addresses"
-      from_port        = 0
-      to_port          = 65535
+      description      = "Allow outbound HTTPS traffic to VPC"
+      //Port 443 is commonly used port for secure HTTPS traffic
+      from_port        = 443
+      to_port          = 443
       protocol         = "tcp"
       cidr_blocks      = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] 
       ipv6_cidr_blocks = ["::/0"]

--- a/terraform-modules/aws/qldb/variables.tf
+++ b/terraform-modules/aws/qldb/variables.tf
@@ -33,3 +33,33 @@ variable "vpc_id" {
   default     = ""
   description = "The vpc ID"
 }
+
+variable "ingress_rule" {
+  type        = list(any)
+  description = "A list of ingress rules"
+  default = [
+    {
+      description      = "All ports from internal addresses"
+      from_port        = 0
+      to_port          = 65535
+      protocol         = "tcp"
+      cidr_blocks      = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+      ipv6_cidr_blocks = []
+    },
+  ]
+}
+
+variable "egress_rule" {
+  type        = list(any)
+  description = "A list of egress rules"
+  default = [
+    {
+      description      = "All ports from internal addresses"
+      from_port        = 0
+      to_port          = 65535
+      protocol         = "tcp"
+      cidr_blocks      = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] 
+      ipv6_cidr_blocks = ["::/0"]
+    },
+  ]
+}


### PR DESCRIPTION
**This PR adds a deployment of Amazon Web Services' Quantum Ledger Database (QLDB) with a VPC endpoint. The following changes have been made to the Terraform configuration:** 

- Added an AWS QLDB ledger resource with the specified name and permissions mode, and with deletion protection enabled to prevent accidental deletion of the ledger.
- Added a security group resource with the specified name and description, and allowing TLS traffic from the VPC and all egress traffic.
- Added an AWS VPC endpoint resource with the QLDB service name, endpoint type and attached to the security group resource. This allows QLDB clients to access the QLDB service using a private IP address within the VPC, without requiring a public IP address or internet gateway.

By deploying QLDB with a VPC endpoint, we are enhancing the security and privacy of our QLDB deployment. By using a private IP address within the VPC, we can ensure that traffic between QLDB clients and the QLDB service remains within the VPC and does not traverse the internet, which reduces the risk of interception or tampering of data.

Additionally, by configuring the security group to allow only TLS traffic from the VPC and all egress traffic, we are implementing a defense-in-depth strategy to protect our QLDB deployment against unauthorized access or attack.

In summary, this PR provides a secure and private deployment of QLDB with a VPC endpoint, which ensures the integrity, confidentiality, and availability of our data in QLDB.

**inputs:**
```
inputs = {
  name                = "${local.account_name}"
  deletion_protection = true
  vpc_id              = dependency.vpc.outputs.vpc_id
  subnet_ids          = [dependency.vpc.outputs.private_subnets[0], dependency.vpc.outputs.private_subnets[1] ]
  tags                = local.tags
}
```

**Terragrunt Apply:**

```
aws_qldb_ledger.this: Creating...
aws_security_group.qldb: Creating...
aws_security_group.qldb: Creation complete after 3s [id=sg-0b5b52130abe0592e]
aws_vpc_endpoint.qldb: Creating...
aws_qldb_ledger.this: Still creating... [10s elapsed]
aws_vpc_endpoint.qldb: Still creating... [10s elapsed]
aws_qldb_ledger.this: Still creating... [20s elapsed]
aws_vpc_endpoint.qldb: Still creating... [20s elapsed]
aws_qldb_ledger.this: Still creating... [30s elapsed]
aws_vpc_endpoint.qldb: Still creating... [30s elapsed]
aws_qldb_ledger.this: Still creating... [40s elapsed]
aws_vpc_endpoint.qldb: Still creating... [40s elapsed]
aws_qldb_ledger.this: Still creating... [50s elapsed]
aws_vpc_endpoint.qldb: Still creating... [51s elapsed]
aws_qldb_ledger.this: Still creating... [1m0s elapsed]
aws_vpc_endpoint.qldb: Still creating... [1m1s elapsed]
aws_qldb_ledger.this: Still creating... [1m10s elapsed]
aws_vpc_endpoint.qldb: Still creating... [1m11s elapsed]
aws_vpc_endpoint.qldb: Creation complete after 1m13s [id=vpce-026ccdf5ce5d2788d]
aws_qldb_ledger.this: Still creating... [1m20s elapsed]
aws_qldb_ledger.this: Still creating... [1m30s elapsed]
aws_qldb_ledger.this: Still creating... [1m40s elapsed]
aws_qldb_ledger.this: Still creating... [1m50s elapsed]
aws_qldb_ledger.this: Still creating... [2m0s elapsed]
aws_qldb_ledger.this: Still creating... [2m10s elapsed]
aws_qldb_ledger.this: Creation complete after 2m14s [id=dp-dev]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

arn = "arn:aws:qldb:us-west-2:042093043970:ledger/dp-dev"
id = "dp-dev"
```
