### PR TITLE
Secret manager module + kms

### DIFF
--- a/terraform-modules/aws/secret-manager/README.md
+++ b/terraform-modules/aws/secret-manager/README.md
@@ -1,3 +1,34 @@
+# AWS Secret Manager
+Certainly! This Terraform configuration creates an empty AWS Secrets Manager secret. 
+When the secret is first created, it doesn't contain any secret value. You will need 
+to add a secret value to the newly created secret manually or programmatically after 
+the secret is created.
+
+To add a secret value to the empty secret, you can do it in two ways:
+
+1. Using the AWS Management Console:
+- Navigate to the AWS Secrets Manager service in the AWS Management Console.
+- Locate the created secret using its name, name prefix, or tags.
+- Click on the secret to view its details.
+- In the "Secret value" section, click on the "Retrieve secret value" button.
+- Click the "Edit" button to add a new secret value.
+- Enter the secret value in the "Plaintext" or "JSON" field, depending on your preference.
+- Click the "Save" button to store the secret value.
+
+2. Using the AWS CLI:
+You can use the aws secretsmanager put-secret-value command to add a secret value to the created 
+secret. Replace <SECRET_ARN> with the ARN of the created secret and <SECRET_VALUE> with the value 
+you want to store in the secret:
+
+```
+aws secretsmanager put-secret-value --secret-id <SECRET_ARN> --secret-string '<SECRET_VALUE>'
+```
+Alternatively, you can use the secret's name instead of the ARN:
+```
+aws secretsmanager put-secret-value --secret-id <SECRET_NAME> --secret-string '<SECRET_VALUE>'
+```
+Once you've added the secret value, you can retrieve it using the AWS Management Console, AWS CLI, SDKs, or APIs when needed.
+
 ## Requirements
 
 No requirements.

--- a/terraform-modules/aws/secret-manager/README.md
+++ b/terraform-modules/aws/secret-manager/README.md
@@ -1,4 +1,5 @@
 # AWS Secret Manager
+
 Certainly! This Terraform configuration creates an empty AWS Secrets Manager secret. 
 When the secret is first created, it doesn't contain any secret value. You will need 
 to add a secret value to the newly created secret manually or programmatically after 
@@ -6,7 +7,7 @@ the secret is created.
 
 To add a secret value to the empty secret, you can do it in two ways:
 
-1. Using the AWS Management Console:
+## 1. Using the AWS Management Console:
 - Navigate to the AWS Secrets Manager service in the AWS Management Console.
 - Locate the created secret using its name, name prefix, or tags.
 - Click on the secret to view its details.
@@ -15,19 +16,25 @@ To add a secret value to the empty secret, you can do it in two ways:
 - Enter the secret value in the "Plaintext" or "JSON" field, depending on your preference.
 - Click the "Save" button to store the secret value.
 
-2. Using the AWS CLI:
-You can use the aws secretsmanager put-secret-value command to add a secret value to the created 
-secret. Replace <SECRET_ARN> with the ARN of the created secret and <SECRET_VALUE> with the value 
+## 2. Using the AWS CLI:
+You can use the `aws secretsmanager put-secret-value` command to add a secret value to the created 
+secret. Replace `<SECRET_ARN>` with the ARN of the created secret and `<SECRET_VALUE>` with the value 
 you want to store in the secret:
 
 ```
 aws secretsmanager put-secret-value --secret-id <SECRET_ARN> --secret-string '<SECRET_VALUE>'
 ```
+
+
 Alternatively, you can use the secret's name instead of the ARN:
+
 ```
 aws secretsmanager put-secret-value --secret-id <SECRET_NAME> --secret-string '<SECRET_VALUE>'
 ```
+
+
 Once you've added the secret value, you can retrieve it using the AWS Management Console, AWS CLI, SDKs, or APIs when needed.
+
 
 ## Requirements
 

--- a/terraform-modules/aws/secret-manager/README.md
+++ b/terraform-modules/aws/secret-manager/README.md
@@ -1,0 +1,42 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_create_kms_key"></a> [create\_kms\_key](#input\_create\_kms\_key) | A boolean flag to indicate whether to create a KMS key or not | `bool` | `false` | no |
+| <a name="input_secretsmanager_kms_deletion_window_in_days"></a> [secretsmanager\_kms\_deletion\_window\_in\_days](#input\_secretsmanager\_kms\_deletion\_window\_in\_days) | The number of days to wait before deleting the KMS key | `number` | `30` | no |
+| <a name="input_secretsmanager_kms_name"></a> [secretsmanager\_kms\_name](#input\_secretsmanager\_kms\_name) | The display name of the KMS key | `string` | `""` | no |
+| <a name="input_secretsmanager_secret_description"></a> [secretsmanager\_secret\_description](#input\_secretsmanager\_secret\_description) | The description of the Secrets Manager secret | `string` | `""` | no |
+| <a name="input_secretsmanager_secret_name"></a> [secretsmanager\_secret\_name](#input\_secretsmanager\_secret\_name) | The name of the Secrets Manager secret | `string` | n/a | yes |
+| <a name="input_secretsmanager_secret_name_prefix"></a> [secretsmanager\_secret\_name\_prefix](#input\_secretsmanager\_secret\_name\_prefix) | A prefix for the Secrets Manager secret name | `string` | `""` | no |
+| <a name="input_secretsmanager_secret_recovery_window_in_days"></a> [secretsmanager\_secret\_recovery\_window\_in\_days](#input\_secretsmanager\_secret\_recovery\_window\_in\_days) | The number of days to wait before deleting the Secrets Manager secret | `number` | `30` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | The Amazon Resource Name (ARN) of the KMS key |
+| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | The globally unique identifier for the KMS key |
+| <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the Secrets Manager secret |
+| <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | ARN of the Secrets Manager secret |

--- a/terraform-modules/aws/secret-manager/README.md
+++ b/terraform-modules/aws/secret-manager/README.md
@@ -1,9 +1,14 @@
 # AWS Secret Manager
-
-Certainly! This Terraform configuration creates an empty AWS Secrets Manager secret. 
+This Terraform configuration creates an empty AWS Secrets Manager secret. 
 When the secret is first created, it doesn't contain any secret value. You will need 
 to add a secret value to the newly created secret manually or programmatically after 
 the secret is created.
+
+# Why you would want to use this module?
+
+To be able to create the AWS Secret resource via IAC but be able to set the actual secret 
+value by ClickOps.
+
 
 To add a secret value to the empty secret, you can do it in two ways:
 

--- a/terraform-modules/aws/secret-manager/main.tf
+++ b/terraform-modules/aws/secret-manager/main.tf
@@ -10,7 +10,6 @@ resource "aws_kms_key" "this" {
 resource "aws_secretsmanager_secret" "this" {
   name                      = var.secretsmanager_secret_name
   description               = var.secretsmanager_secret_description
-  name_prefix               = var.secretsmanager_secret_name_prefix
   recovery_window_in_days   = var.secretsmanager_secret_recovery_window_in_days
   
   #If you don't specify this value, then Secrets Manager defaults to using the AWS account's default KMS key (the one named aws/secretsmanager

--- a/terraform-modules/aws/secret-manager/main.tf
+++ b/terraform-modules/aws/secret-manager/main.tf
@@ -1,6 +1,6 @@
 # Creates the KMS key only when the create_kms_key variable is set to false.
 resource "aws_kms_key" "this" {
-  count                   = var.create_kms_key ? 0 : 1
+  count                   = var.create_kms_key ? 1 : 0
   description             = var.secretsmanager_kms_name
   deletion_window_in_days = var.secretsmanager_kms_deletion_window_in_days
   tags                    = var.tags
@@ -13,7 +13,7 @@ resource "aws_secretsmanager_secret" "this" {
   recovery_window_in_days   = var.secretsmanager_secret_recovery_window_in_days
   
   #If you don't specify this value, then Secrets Manager defaults to using the AWS account's default KMS key (the one named aws/secretsmanager
-  kms_key_id                = var.create_kms_key ? null : aws_kms_key.this[0].id
+  kms_key_id                = var.create_kms_key ? aws_kms_key.this[0].id : null
   
   tags                      = var.tags
 }

--- a/terraform-modules/aws/secret-manager/main.tf
+++ b/terraform-modules/aws/secret-manager/main.tf
@@ -7,8 +7,9 @@ resource "aws_kms_key" "this" {
 }
 
 resource "aws_kms_alias" "a" {
+  count         = var.create_kms_key ? 1 : 0
   name          = "alias/${var.secretsmanager_kms_name_alias}"
-  target_key_id = aws_kms_key.this.key_id
+  target_key_id = aws_kms_key.this[0].key_id
 }
 
 # Creates the Secrets Manager secret.

--- a/terraform-modules/aws/secret-manager/main.tf
+++ b/terraform-modules/aws/secret-manager/main.tf
@@ -6,6 +6,11 @@ resource "aws_kms_key" "this" {
   tags                    = var.tags
 }
 
+resource "aws_kms_alias" "a" {
+  name          = "alias/${var.secretsmanager_kms_name_alias}"
+  target_key_id = aws_kms_key.this.key_id
+}
+
 # Creates the Secrets Manager secret.
 resource "aws_secretsmanager_secret" "this" {
   name                      = var.secretsmanager_secret_name

--- a/terraform-modules/aws/secret-manager/main.tf
+++ b/terraform-modules/aws/secret-manager/main.tf
@@ -1,0 +1,20 @@
+# Creates the KMS key only when the create_kms_key variable is set to false.
+resource "aws_kms_key" "this" {
+  count                   = var.create_kms_key ? 0 : 1
+  description             = var.secretsmanager_kms_name
+  deletion_window_in_days = var.secretsmanager_kms_deletion_window_in_days
+  tags                    = var.tags
+}
+
+# Creates the Secrets Manager secret.
+resource "aws_secretsmanager_secret" "this" {
+  name                      = var.secretsmanager_secret_name
+  description               = var.secretsmanager_secret_description
+  name_prefix               = var.secretsmanager_secret_name_prefix
+  recovery_window_in_days   = var.secretsmanager_secret_recovery_window_in_days
+  
+  #If you don't specify this value, then Secrets Manager defaults to using the AWS account's default KMS key (the one named aws/secretsmanager
+  kms_key_id                = var.create_kms_key ? null : aws_kms_key.this[0].id
+  
+  tags                      = var.tags
+}

--- a/terraform-modules/aws/secret-manager/outputs.tf
+++ b/terraform-modules/aws/secret-manager/outputs.tf
@@ -1,0 +1,19 @@
+output "secret_id" {
+  description = "ARN of the Secrets Manager secret"
+  value       = aws_secretsmanager_secret.this.id
+}
+
+output "secret_arn" {
+  description = "ARN of the Secrets Manager secret"
+  value       = aws_secretsmanager_secret.this
+}
+
+output "kms_key_arn" {
+  description = "The Amazon Resource Name (ARN) of the KMS key"
+  value       = var.create_kms_key ? null : aws_kms_key.this[0].arn
+}
+
+output "kms_key_id" {
+  description = "The globally unique identifier for the KMS key"
+  value       = var.create_kms_key ? null : aws_kms_key.this[0].key_id
+}

--- a/terraform-modules/aws/secret-manager/outputs.tf
+++ b/terraform-modules/aws/secret-manager/outputs.tf
@@ -10,10 +10,10 @@ output "secret_arn" {
 
 output "kms_key_arn" {
   description = "The Amazon Resource Name (ARN) of the KMS key"
-  value       = var.create_kms_key ? null : aws_kms_key.this[0].arn
+  value       = var.create_kms_key ? aws_kms_key.this[0].arn : null
 }
 
 output "kms_key_id" {
   description = "The globally unique identifier for the KMS key"
-  value       = var.create_kms_key ? null : aws_kms_key.this[0].key_id
+  value       = var.create_kms_key ? aws_kms_key.this[0].key_id : null
 }

--- a/terraform-modules/aws/secret-manager/outputs.tf
+++ b/terraform-modules/aws/secret-manager/outputs.tf
@@ -1,11 +1,11 @@
 output "secret_id" {
-  description = "ARN of the Secrets Manager secret"
+  description = "Id of the Secrets Manager secret"
   value       = aws_secretsmanager_secret.this.id
 }
 
 output "secret_arn" {
   description = "ARN of the Secrets Manager secret"
-  value       = aws_secretsmanager_secret.this
+  value       = aws_secretsmanager_secret.this.arn
 }
 
 output "kms_key_arn" {

--- a/terraform-modules/aws/secret-manager/variables.tf
+++ b/terraform-modules/aws/secret-manager/variables.tf
@@ -28,12 +28,6 @@ variable "secretsmanager_secret_description" {
   default     = ""
 }
 
-variable "secretsmanager_secret_name_prefix" {
-  description = "A prefix for the Secrets Manager secret name"
-  type        = string
-  default     = ""
-}
-
 variable "secretsmanager_secret_recovery_window_in_days" {
   description = "The number of days to wait before deleting the Secrets Manager secret"
   type        = number

--- a/terraform-modules/aws/secret-manager/variables.tf
+++ b/terraform-modules/aws/secret-manager/variables.tf
@@ -11,6 +11,12 @@ variable "secretsmanager_kms_name" {
   default     = ""
 }
 
+variable "secretsmanager_kms_name_alias" {
+  description = "The Alias name of the KMS key"
+  type        = string
+  default     = ""
+}
+
 variable "secretsmanager_kms_deletion_window_in_days" {
   description = "The number of days to wait before deleting the KMS key"
   type        = number

--- a/terraform-modules/aws/secret-manager/variables.tf
+++ b/terraform-modules/aws/secret-manager/variables.tf
@@ -1,0 +1,47 @@
+# Controls whether to create a KMS key or not.
+variable "create_kms_key" {
+  description = "A boolean flag to indicate whether to create a KMS key or not"
+  type        = bool
+  default     = false
+}
+
+variable "secretsmanager_kms_name" {
+  description = "The display name of the KMS key"
+  type        = string
+  default     = ""
+}
+
+variable "secretsmanager_kms_deletion_window_in_days" {
+  description = "The number of days to wait before deleting the KMS key"
+  type        = number
+  default     = 30
+}
+
+variable "secretsmanager_secret_name" {
+  description = "The name of the Secrets Manager secret"
+  type        = string
+}
+
+variable "secretsmanager_secret_description" {
+  description = "The description of the Secrets Manager secret"
+  type        = string
+  default     = ""
+}
+
+variable "secretsmanager_secret_name_prefix" {
+  description = "A prefix for the Secrets Manager secret name"
+  type        = string
+  default     = ""
+}
+
+variable "secretsmanager_secret_recovery_window_in_days" {
+  description = "The number of days to wait before deleting the Secrets Manager secret"
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
# What
Creates a modules to new aws secret manager + kms

# Evidence in aws console
![Screenshot 2023-04-20 at 09 17 23](https://user-images.githubusercontent.com/19688747/2334111
84-6e218ef9-4b69-4737-83e5-de5e0e323ffa.png)
![Screenshot 2023-04-20 at 09 17 51](https://user-images.githubusercontent.com/19688747/233411304-46a96d61-05cc-4bf7-aeb2-fc40b04c4108.png)
![Screenshot 2023-04-20 at 09 18 27](https://user-images.githubusercontent.com/19688747/233411467-df6f80a3-7724-4b22-b939-1b993c3a38e9.png)


# Plan
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_kms_key.this[0] will be created
  + resource "aws_kms_key" "this" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 30
      + description                        = "AmazonMSK_dp-dev-kafka-user-kms"
      + enable_key_rotation                = false
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags                               = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0250-secret-manager-kafka-user"
        }
      + tags_all                           = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0250-secret-manager-kafka-user"
        }
    }

  # aws_secretsmanager_secret.this will be created
  + resource "aws_secretsmanager_secret" "this" {
      + arn                            = (known after apply)
      + description                    = "AmazonMSK_dp-dev-kafka-user in order to connect EMR to Kafka"
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + kms_key_id                     = (known after apply)
      + name                           = "AmazonMSK_dp-dev-kafka-user"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + rotation_enabled               = (known after apply)
      + rotation_lambda_arn            = (known after apply)
      + tags                           = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0250-secret-manager-kafka-user"
        }
      + tags_all                       = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0250-secret-manager-kafka-user"
        }

      + replica {
          + kms_key_id         = (known after apply)
          + last_accessed_date = (known after apply)
          + region             = (known after apply)
          + status             = (known after apply)
          + status_message     = (known after apply)
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
          + duration                 = (known after apply)
          + schedule_expression      = (known after apply)
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + secret_arn = (known after apply)
  + secret_id  = (known after apply)

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
```
# Where I am using this branch
https://github.com/exact-payments/gruntwork-infrastructure-live/pull/1608/files#diff-5fa1aa009548ff8bae18ba76830e6edde43bc7cff712aa5bb42b3916fe362ee8R12
