### PR TITLE
Airflow Extra Policy + Extra Sgs

### DIFF
--- a/terraform-modules/aws/airflow/README.md
+++ b/terraform-modules/aws/airflow/README.md
@@ -1,0 +1,62 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_iam_assumable_role_admin"></a> [iam\_assumable\_role\_admin](#module\_iam\_assumable\_role\_admin) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.11.2 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.extra-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_mwaa_environment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mwaa_environment) | resource |
+| [aws_s3_bucket.airflow](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_airflow_name"></a> [airflow\_name](#input\_airflow\_name) | Airflow name | `string` | `"airflow"` | no |
+| <a name="input_airflow_version"></a> [airflow\_version](#input\_airflow\_version) | (Optional) Airflow version of your environment, will be set by default to the latest version that MWAA supports. | `string` | `null` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region | `string` | `"us-east-1"` | no |
+| <a name="input_dag_processing_log_level"></a> [dag\_processing\_log\_level](#input\_dag\_processing\_log\_level) | The log level: INFO \| WARNING \| ERROR \| CRITICAL | `string` | `"INFO"` | no |
+| <a name="input_dag_s3_path"></a> [dag\_s3\_path](#input\_dag\_s3\_path) | The dag's S3 path | `string` | `"dags/"` | no |
+| <a name="input_environment_class"></a> [environment\_class](#input\_environment\_class) | (Optional) Environment class for the cluster. Possible options are mw1.small, mw1.medium, mw1.large. Will be set by default to mw1.small. Please check the AWS Pricing for more information about the environment classes. | `string` | `"mw1.small"` | no |
+| <a name="input_iam_extra_policies"></a> [iam\_extra\_policies](#input\_iam\_extra\_policies) | List of additional policies to create and attach to the IAM role | <pre>list(object({<br>    name_prefix = string<br>    policy_json = string<br>  }))</pre> | `[]` | no |
+| <a name="input_max_workers"></a> [max\_workers](#input\_max\_workers) | (Optional) The maximum number of workers that can be automatically scaled up. Value need to be between 1 and 25. Will be 10 by default. | `number` | `10` | no |
+| <a name="input_min_workers"></a> [min\_workers](#input\_min\_workers) | (Optional) The minimum number of workers that you want to run in your environment. Will be 1 by default. | `number` | `1` | no |
+| <a name="input_scheduler_log_level"></a> [scheduler\_log\_level](#input\_scheduler\_log\_level) | The log level: INFO \| WARNING \| ERROR \| CRITICAL | `string` | `"INFO"` | no |
+| <a name="input_sg_extra_ids"></a> [sg\_extra\_ids](#input\_sg\_extra\_ids) | List of additional sg to create and attach to Airflow | `list(string)` | `[]` | no |
+| <a name="input_source_bucket_arn"></a> [source\_bucket\_arn](#input\_source\_bucket\_arn) | The Dag's S3 bucket arn: arn:aws:s3:::bucketname | `string` | `"s3://foo"` | no |
+| <a name="input_source_bucket_name"></a> [source\_bucket\_name](#input\_source\_bucket\_name) | The Dag's S3 bucket name | `string` | `"foo"` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | (Required) The private subnet IDs in which the environment should be created. MWAA requires two subnets. | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A set of tags to place on the items | `any` | `{}` | no |
+| <a name="input_task_log_level"></a> [task\_log\_level](#input\_task\_log\_level) | The log level: INFO \| WARNING \| ERROR \| CRITICAL | `string` | `"INFO"` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The vpc ID | `string` | `""` | no |
+| <a name="input_webserver_access_mode"></a> [webserver\_access\_mode](#input\_webserver\_access\_mode) | (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE\_ONLY (default) and PUBLIC\_ONLY | `string` | `"PRIVATE_ONLY"` | no |
+| <a name="input_webserver_log_level"></a> [webserver\_log\_level](#input\_webserver\_log\_level) | The log level: INFO \| WARNING \| ERROR \| CRITICAL | `string` | `"INFO"` | no |
+| <a name="input_worker_log_level"></a> [worker\_log\_level](#input\_worker\_log\_level) | The log level: INFO \| WARNING \| ERROR \| CRITICAL | `string` | `"INFO"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | n/a |
+| <a name="output_webserver_url"></a> [webserver\_url](#output\_webserver\_url) | n/a |

--- a/terraform-modules/aws/airflow/main.tf
+++ b/terraform-modules/aws/airflow/main.tf
@@ -95,7 +95,7 @@ module "iam_assumable_role_admin" {
   role_name               = "airflow-${var.airflow_name}"
   role_description        = "Airflow role"
   trusted_role_services   = ["airflow.amazonaws.com","airflow-env.amazonaws.com"]
-  custom_role_policy_arns = concat([aws_iam_policy.policy.arn], [for policy in aws_iam_policy.iam_extra_policies : policy.arn])
+  custom_role_policy_arns = concat([aws_iam_policy.policy.arn], [for policy in var.iam_extra_policies : policy.policy_json])
   role_requires_mfa       = false
   tags                    = var.tags
 }

--- a/terraform-modules/aws/airflow/main.tf
+++ b/terraform-modules/aws/airflow/main.tf
@@ -95,7 +95,7 @@ module "iam_assumable_role_admin" {
   role_name               = "airflow-${var.airflow_name}"
   role_description        = "Airflow role"
   trusted_role_services   = ["airflow.amazonaws.com","airflow-env.amazonaws.com"]
-  custom_role_policy_arns = concat([aws_iam_policy.policy.arn], [for policy in var.iam_extra_policies : policy.policy_json])
+  custom_role_policy_arns = concat([aws_iam_policy.policy.arn], [for policy in aws_iam_policy.extra-policy : policy.arn])
   role_requires_mfa       = false
   tags                    = var.tags
 }

--- a/terraform-modules/aws/airflow/main.tf
+++ b/terraform-modules/aws/airflow/main.tf
@@ -45,6 +45,7 @@ resource "aws_mwaa_environment" "this" {
   dag_s3_path        = var.dag_s3_path
   execution_role_arn = module.iam_assumable_role_admin.iam_role_arn
   webserver_access_mode = var.webserver_access_mode
+  requirements_s3_path  = var.requirements_s3_path
 
   logging_configuration {
     dag_processing_logs {

--- a/terraform-modules/aws/airflow/variables.tf
+++ b/terraform-modules/aws/airflow/variables.tf
@@ -128,3 +128,9 @@ variable "sg_extra_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "requirements_s3_path" {
+  description = "The S3 path for the MWAA requirements file."
+  type        = string
+  default     = ""
+}

--- a/terraform-modules/aws/airflow/variables.tf
+++ b/terraform-modules/aws/airflow/variables.tf
@@ -113,3 +113,18 @@ variable "webserver_access_mode" {
     error_message = "Invalid input, options: \"PRIVATE_ONLY\", \"PUBLIC_ONLY\"."
   }
 }
+
+variable "iam_extra_policies" {
+  description = "List of additional policies to create and attach to the IAM role"
+  type        = list(object({
+    name_prefix = string
+    policy_json = string
+  }))
+  default     = []
+}
+
+variable "sg_extra_ids" {
+  description = "List of additional sg to create and attach to Airflow"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
# What
I am incrementing functionality to Airflow terraform in managed kube adding three news environment variables such as
```
variable "iam_extra_policies" {
  description = "List of additional policies to create and attach to the IAM role"
  type        = list(object({
    name_prefix = string
    policy_json = string
  }))
  default     = []
}

variable "sg_extra_ids" {
  description = "List of additional sg to create and attach to Airflow"
  type        = list(string)
  default     = []
}

variable "requirements_s3_path" {
  description = "The S3 path for the MWAA requirements file."
  type        = string
  default     = ""
}
```
Here's a human explanation of these variables:

    iam_extra_policies:

This variable is for a list of additional policies that you want to create and attach to an Identity and Access Management (IAM) role. Each policy in the list should be an object containing two properties:

a. name_prefix: A string value that represents the prefix of the policy name.
b. policy_json: A string value containing the JSON content of the policy.

By default, the list is empty, meaning no additional policies will be created or attached.

    sg_extra_ids:

This variable represents a list of additional security group (sg) IDs that you want to create and attach to the Airflow environment. The list should consist of string values, with each string being an ID for a security group. By default, the list is empty, meaning no additional security groups will be created or attached.

    requirements_s3_path:

This variable is for specifying the Amazon S3 path where the Managed Workflows for Apache Airflow (MWAA) requirements file is located. The value should be a string representing the S3 path. By default, the value is an empty string, which means that no specific path is set.

# What's going on with the security group and the policy already implemented?
it keeps using, but we are using `concat` in both cases, which means currently sg and IAM is in index 0 and we can send customized things from index 1 to ahead.


# AWS Console Evidence
- New two policies 
![Screenshot 2023-04-24 at 10 47 51](https://user-images.githubusercontent.com/19688747/234062959-5678bbfb-4651-4bdf-aa34-dc77a1c820b4.png)

- Sg Associated

<img width="886" alt="Screenshot 2023-04-24 at 10 49 00" src="https://user-images.githubusercontent.com/19688747/234063219-1f3d782d-5f77-4d56-9871-ddafe144982e.png">


# Where are using this branch.
- pointing to branch: https://github.com/exact-payments/gruntwork-infrastructure-live/pull/1624/files#diff-e4143fcd8122afe514798c50b3da9921016ca80f396b4e1e4743c4c667ffce12R4
- using the new env vars : https://github.com/exact-payments/gruntwork-infrastructure-live/pull/1624/files#diff-e4143fcd8122afe514798c50b3da9921016ca80f396b4e1e4743c4c667ffce12R99-R132

# Terraform
root@180300e9c152:/workspaces/gruntwork-infrastructure-live/dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow# terragrunt plan
Acquiring state lock. This may take a few moments...
module.iam_assumable_role_admin.data.aws_caller_identity.current: Reading...
data.aws_caller_identity.current: Reading...
module.iam_assumable_role_admin.data.aws_partition.current: Reading...
aws_security_group.this: Refreshing state... [id=sg-097feb78673f3f18a]
module.iam_assumable_role_admin.data.aws_partition.current: Read complete after 0s [id=aws]
aws_s3_bucket.airflow: Refreshing state... [id=airflow-s3-dp-dev]
data.aws_caller_identity.current: Read complete after 0s [id=042093043970]
module.iam_assumable_role_admin.data.aws_caller_identity.current: Read complete after 0s [id=042093043970]
aws_iam_policy.policy: Refreshing state... [id=arn:aws:iam::042093043970:policy/cluster-autoscaler-dp-dev-airflow20230329191614997200000001]
module.iam_assumable_role_admin.data.aws_iam_policy_document.assume_role[0]: Reading...
module.iam_assumable_role_admin.data.aws_iam_policy_document.assume_role[0]: Read complete after 0s [id=3831769836]
module.iam_assumable_role_admin.aws_iam_role.this[0]: Refreshing state... [id=airflow-dp-dev-airflow]
module.iam_assumable_role_admin.aws_iam_role_policy_attachment.custom[0]: Refreshing state... [id=airflow-dp-dev-airflow-20230329191615512500000002]
aws_s3_bucket_public_access_block.this: Refreshing state... [id=airflow-s3-dp-dev]
aws_s3_bucket_server_side_encryption_configuration.this: Refreshing state... [id=airflow-s3-dp-dev]
aws_s3_bucket_versioning.this: Refreshing state... [id=airflow-s3-dp-dev]
aws_s3_bucket_acl.this: Refreshing state... [id=airflow-s3-dp-dev,private]
aws_mwaa_environment.this: Refreshing state... [id=dp-dev-airflow]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

```
  # aws_iam_policy.extra-policy[0] will be created
  + resource "aws_iam_policy" "extra-policy" {
      + arn         = (known after apply)
      + description = "Airflow extra policy 0"
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = "dp-dev-airflow-kafka-inline-policy-dp-dev-airflow"
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "secretsmanager:GetSecretValue",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:secretsmanager:us-west-2:042093043970:secret:AmazonMSK_dp-dev-kafka-user-Fs8Jx1"
                    },
                  + {
                      + Action   = [
                          + "kms:Decrypt",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:kms:us-west-2:042093043970:key/dbc92524-dc16-40c8-83fb-0116624341e5"
                    },
                  + {
                      + Action   = [
                          + "kafka-cluster:Connect",
                          + "kafka-cluster:AlterCluster",
                          + "kafka-cluster:DescribeCluster",
                          + "kafka:GetBootstrapBrokers",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:cluster/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "kafka-cluster:*Topic*",
                          + "kafka-cluster:WriteData",
                          + "kafka-cluster:ReadData",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:topic/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "kafka-cluster:AlterGroup",
                          + "kafka-cluster:DescribeGroup",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:group/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "kafka:*",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:cluster/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "qldb:CreateLedger",
                          + "qldb:UpdateLedger",
                          + "qldb:ListLedgers",
                          + "qldb:DescribeLedger",
                          + "qldb:ExportJournalToS3",
                          + "qldb:ListJournalS3Exports",
                          + "qldb:ListJournalS3ExportsForLedger",
                          + "qldb:DescribeJournalS3Export",
                          + "qldb:CancelJournalKinesisStream",
                          + "qldb:DescribeJournalKinesisStream",
                          + "qldb:ListJournalKinesisStreamsForLedger",
                          + "qldb:StreamJournalToKinesis",
                          + "qldb:GetDigest",
                          + "qldb:GetRevision",
                          + "qldb:GetBlock",
                          + "qldb:TagResource",
                          + "qldb:UntagResource",
                          + "qldb:ListTagsForResource",
                          + "qldb:SendCommand",
                          + "qldb:PartiQLCreateIndex",
                          + "qldb:PartiQLInsert",
                          + "qldb:PartiQLUpdate",
                          + "qldb:PartiQLSelect",
                          + "qldb:PartiQLHistoryFunction",
                          + "qldb:PartiQLRedact",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:qldb:us-west-2:042093043970:ledger/dp-dev",
                        ]
                    },
                  + {
                      + Action    = "iam:PassRole"
                      + Condition = {
                          + StringEquals = {
                              + "iam:PassedToService" = "qldb.amazonaws.com"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                    },
                  + {
                      + Action    = [
                          + "elasticmapreduce:RunJobFlow",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + "aws:RequestTag/for-use-with-amazon-emr-managed-policies" = "true"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                      + Sid       = "RunJobFlowExplicitlyWithEMRManagedTag"
                    },
                  + {
                      + Action   = [
                          + "elasticmapreduce:AddInstanceFleet",
                          + "elasticmapreduce:AddInstanceGroups",
                          + "elasticmapreduce:AddJobFlowSteps",
                          + "elasticmapreduce:AddTags",
                          + "elasticmapreduce:CancelSteps",
                          + "elasticmapreduce:CreateEditor",
                          + "elasticmapreduce:CreateSecurityConfiguration",
                          + "elasticmapreduce:DeleteEditor",
                          + "elasticmapreduce:DeleteSecurityConfiguration",
                          + "elasticmapreduce:DescribeCluster",
                          + "elasticmapreduce:DescribeEditor",
                          + "elasticmapreduce:DescribeJobFlows",
                          + "elasticmapreduce:DescribeSecurityConfiguration",
                          + "elasticmapreduce:DescribeStep",
                          + "elasticmapreduce:DescribeReleaseLabel",
                          + "elasticmapreduce:GetBlockPublicAccessConfiguration",
                          + "elasticmapreduce:GetManagedScalingPolicy",
                          + "elasticmapreduce:GetAutoTerminationPolicy",
                          + "elasticmapreduce:ListBootstrapActions",
                          + "elasticmapreduce:ListClusters",
                          + "elasticmapreduce:ListEditors",
                          + "elasticmapreduce:ListInstanceFleets",
                          + "elasticmapreduce:ListInstanceGroups",
                          + "elasticmapreduce:ListInstances",
                          + "elasticmapreduce:ListSecurityConfigurations",
                          + "elasticmapreduce:ListSteps",
                          + "elasticmapreduce:ModifyCluster",
                          + "elasticmapreduce:ModifyInstanceFleet",
                          + "elasticmapreduce:ModifyInstanceGroups",
                          + "elasticmapreduce:OpenEditorInConsole",
                          + "elasticmapreduce:PutAutoScalingPolicy",
                          + "elasticmapreduce:PutBlockPublicAccessConfiguration",
                          + "elasticmapreduce:PutManagedScalingPolicy",
                          + "elasticmapreduce:RemoveAutoScalingPolicy",
                          + "elasticmapreduce:RemoveManagedScalingPolicy",
                          + "elasticmapreduce:RemoveTags",
                          + "elasticmapreduce:SetTerminationProtection",
                          + "elasticmapreduce:StartEditor",
                          + "elasticmapreduce:StopEditor",
                          + "elasticmapreduce:TerminateJobFlows",
                          + "elasticmapreduce:ViewEventsFromAllClustersInConsole",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "ElasticMapReduceActions"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags        = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow"
        }
      + tags_all    = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow"
        }
    }

  # aws_iam_policy.extra-policy[1] will be created
  + resource "aws_iam_policy" "extra-policy" {
      + arn         = (known after apply)
      + description = "Airflow extra policy 1"
      + id          = (known after apply)
      + name        = (known after apply)
      + name_prefix = "dp-dev-s3-bucket-inline-policy-dp-dev-airflow"
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "s3:ListAllMyBuckets"
                      + Effect   = "Deny"
                      + Resource = [
                          + "arn:aws:s3:::ep-raw-zone",
                          + "arn:aws:s3:::ep-raw-zone/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "s3:PutObject*",
                          + "s3:DeleteObject*",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::ep-raw-zone",
                          + "arn:aws:s3:::ep-raw-zone/*",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags        = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow"
        }
      + tags_all    = {
          + "ops_env"              = "dp-dev"
          + "ops_managed_by"       = "terraform"
          + "ops_owners"           = "devops"
          + "ops_source_repo"      = "gruntwork-infrastructure-live"
          + "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow"
        }
    }

  # aws_iam_policy.policy will be updated in-place
  ~ resource "aws_iam_policy" "policy" {
        id          = "arn:aws:iam::042093043970:policy/cluster-autoscaler-dp-dev-airflow20230329191614997200000001"
        name        = "cluster-autoscaler-dp-dev-airflow20230329191614997200000001"
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = "airflow:PublishMetrics"
                        Effect   = "Allow"
                        Resource = "arn:aws:airflow:us-west-2:042093043970:environment/dp-dev-airflow"
                    },
                  ~ {
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:s3:::airflow-s3-dp-dev/*",
                          - "arn:aws:s3:::ep-raw-zone",
                          - "arn:aws:s3:::ep-raw-zone/*",
                        ]
                        # (2 unchanged elements hidden)
                    },
                  ~ {
                      ~ Action   = [
                            # (2 unchanged elements hidden)
                            "s3:List*",
                          - "s3:PutObject*",
                          - "s3:DeleteObject*",
                        ]
                      ~ Resource = [
                            # (1 unchanged element hidden)
                            "arn:aws:s3:::airflow-s3-dp-dev/*",
                          - "arn:aws:s3:::ep-raw-zone",
                          - "arn:aws:s3:::ep-raw-zone/*",
                        ]
                        # (1 unchanged element hidden)
                    },
                    {
                        Action   = [
                            "logs:CreateLogStream",
                            "logs:CreateLogGroup",
                            "logs:PutLogEvents",
                            "logs:GetLogEvents",
                            "logs:GetLogRecord",
                            "logs:GetLogGroupFields",
                            "logs:GetQueryResults",
                        ]
                        Effect   = "Allow"
                        Resource = [
                            "arn:aws:logs:us-west-2:042093043970:log-group:airflow-dp-dev-airflow-*",
                        ]
                    },
                    # (3 unchanged elements hidden)
                    {
                        Action   = [
                            "sqs:ChangeMessageVisibility",
                            "sqs:DeleteMessage",
                            "sqs:GetQueueAttributes",
                            "sqs:GetQueueUrl",
                            "sqs:ReceiveMessage",
                            "sqs:SendMessage",
                        ]
                        Effect   = "Allow"
                        Resource = "arn:aws:sqs:us-west-2:*:airflow-celery-*"
                    },
                  ~ {
                      ~ Resource  = "*" -> "arn:aws:kms:us-west-2:042093043970:key/*"
                        # (3 unchanged elements hidden)
                    },
                  - {
                      - Action   = [
                          - "kafka:*",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:kafka:us-west-2:042093043970:cluster/exactpay-dp-dev/0044f909-27a4-46c8-a5a6-58ce53399c32-12",
                        ]
                    },
                  - {
                      - Action   = [
                          - "qldb:CreateLedger",
                          - "qldb:UpdateLedger",
                          - "qldb:ListLedgers",
                          - "qldb:DescribeLedger",
                          - "qldb:ExportJournalToS3",
                          - "qldb:ListJournalS3Exports",
                          - "qldb:ListJournalS3ExportsForLedger",
                          - "qldb:DescribeJournalS3Export",
                          - "qldb:CancelJournalKinesisStream",
                          - "qldb:DescribeJournalKinesisStream",
                          - "qldb:ListJournalKinesisStreamsForLedger",
                          - "qldb:StreamJournalToKinesis",
                          - "qldb:GetDigest",
                          - "qldb:GetRevision",
                          - "qldb:GetBlock",
                          - "qldb:TagResource",
                          - "qldb:UntagResource",
                          - "qldb:ListTagsForResource",
                          - "qldb:SendCommand",
                          - "qldb:PartiQLCreateIndex",
                          - "qldb:PartiQLInsert",
                          - "qldb:PartiQLUpdate",
                          - "qldb:PartiQLSelect",
                          - "qldb:PartiQLHistoryFunction",
                          - "qldb:PartiQLRedact",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "arn:aws:qldb:us-west-2:042093043970:ledger/dp-dev",
                        ]
                    },
                  - {
                      - Action    = "iam:PassRole"
                      - Condition = {
                          - StringEquals = {
                              - "iam:PassedToService" = "qldb.amazonaws.com"
                            }
                        }
                      - Effect    = "Allow"
                      - Resource  = "*"
                    },
                  - {
                      - Action    = [
                          - "elasticmapreduce:RunJobFlow",
                        ]
                      - Condition = {
                          - StringEquals = {
                              - "aws:RequestTag/for-use-with-amazon-emr-managed-policies" = "true"
                            }
                        }
                      - Effect    = "Allow"
                      - Resource  = "*"
                      - Sid       = "RunJobFlowExplicitlyWithEMRManagedTag"
                    },
                  - {
                      - Action   = [
                          - "elasticmapreduce:AddInstanceFleet",
                          - "elasticmapreduce:AddInstanceGroups",
                          - "elasticmapreduce:AddJobFlowSteps",
                          - "elasticmapreduce:AddTags",
                          - "elasticmapreduce:CancelSteps",
                          - "elasticmapreduce:CreateEditor",
                          - "elasticmapreduce:CreateSecurityConfiguration",
                          - "elasticmapreduce:DeleteEditor",
                          - "elasticmapreduce:DeleteSecurityConfiguration",
                          - "elasticmapreduce:DescribeCluster",
                          - "elasticmapreduce:DescribeEditor",
                          - "elasticmapreduce:DescribeJobFlows",
                          - "elasticmapreduce:DescribeSecurityConfiguration",
                          - "elasticmapreduce:DescribeStep",
                          - "elasticmapreduce:DescribeReleaseLabel",
                          - "elasticmapreduce:GetBlockPublicAccessConfiguration",
                          - "elasticmapreduce:GetManagedScalingPolicy",
                          - "elasticmapreduce:GetAutoTerminationPolicy",
                          - "elasticmapreduce:ListBootstrapActions",
                          - "elasticmapreduce:ListClusters",
                          - "elasticmapreduce:ListEditors",
                          - "elasticmapreduce:ListInstanceFleets",
                          - "elasticmapreduce:ListInstanceGroups",
                          - "elasticmapreduce:ListInstances",
                          - "elasticmapreduce:ListSecurityConfigurations",
                          - "elasticmapreduce:ListSteps",
                          - "elasticmapreduce:ModifyCluster",
                          - "elasticmapreduce:ModifyInstanceFleet",
                          - "elasticmapreduce:ModifyInstanceGroups",
                          - "elasticmapreduce:OpenEditorInConsole",
                          - "elasticmapreduce:PutAutoScalingPolicy",
                          - "elasticmapreduce:PutBlockPublicAccessConfiguration",
                          - "elasticmapreduce:PutManagedScalingPolicy",
                          - "elasticmapreduce:RemoveAutoScalingPolicy",
                          - "elasticmapreduce:RemoveManagedScalingPolicy",
                          - "elasticmapreduce:RemoveTags",
                          - "elasticmapreduce:SetTerminationProtection",
                          - "elasticmapreduce:StartEditor",
                          - "elasticmapreduce:StopEditor",
                          - "elasticmapreduce:TerminateJobFlows",
                          - "elasticmapreduce:ViewEventsFromAllClustersInConsole",
                        ]
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = "ElasticMapReduceActions"
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        tags        = {
            "ops_env"              = "dp-dev"
            "ops_managed_by"       = "terraform"
            "ops_owners"           = "devops"
            "ops_source_repo"      = "gruntwork-infrastructure-live"
            "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow"
        }
        # (6 unchanged attributes hidden)
    }

  # aws_mwaa_environment.this will be updated in-place
  ~ resource "aws_mwaa_environment" "this" {
        id                              = "dp-dev-airflow"
        name                            = "dp-dev-airflow"
      - requirements_s3_path            = "requirements.txt" -> null
        tags                            = {
            "ops_env"              = "dp-dev"
            "ops_managed_by"       = "terraform"
            "ops_owners"           = "devops"
            "ops_source_repo"      = "gruntwork-infrastructure-live"
            "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow"
        }
        # (19 unchanged attributes hidden)

      ~ network_configuration {
          ~ security_group_ids = [
              + "sg-0ec660ac5dd04cce4",
                # (1 unchanged element hidden)
            ]
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.iam_assumable_role_admin.aws_iam_role_policy_attachment.custom[1] will be created
  + resource "aws_iam_role_policy_attachment" "custom" {
      + id         = (known after apply)
      + policy_arn = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "secretsmanager:GetSecretValue",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:secretsmanager:us-west-2:042093043970:secret:AmazonMSK_dp-dev-kafka-user-Fs8Jx1"
                    },
                  + {
                      + Action   = [
                          + "kms:Decrypt",
                        ]
                      + Effect   = "Allow"
                      + Resource = "arn:aws:kms:us-west-2:042093043970:key/dbc92524-dc16-40c8-83fb-0116624341e5"
                    },
                  + {
                      + Action   = [
                          + "kafka-cluster:Connect",
                          + "kafka-cluster:AlterCluster",
                          + "kafka-cluster:DescribeCluster",
                          + "kafka:GetBootstrapBrokers",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:cluster/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "kafka-cluster:*Topic*",
                          + "kafka-cluster:WriteData",
                          + "kafka-cluster:ReadData",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:topic/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "kafka-cluster:AlterGroup",
                          + "kafka-cluster:DescribeGroup",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:group/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "kafka:*",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:kafka:us-west-2:042093043970:cluster/exactpay-dp-dev/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "qldb:CreateLedger",
                          + "qldb:UpdateLedger",
                          + "qldb:ListLedgers",
                          + "qldb:DescribeLedger",
                          + "qldb:ExportJournalToS3",
                          + "qldb:ListJournalS3Exports",
                          + "qldb:ListJournalS3ExportsForLedger",
                          + "qldb:DescribeJournalS3Export",
                          + "qldb:CancelJournalKinesisStream",
                          + "qldb:DescribeJournalKinesisStream",
                          + "qldb:ListJournalKinesisStreamsForLedger",
                          + "qldb:StreamJournalToKinesis",
                          + "qldb:GetDigest",
                          + "qldb:GetRevision",
                          + "qldb:GetBlock",
                          + "qldb:TagResource",
                          + "qldb:UntagResource",
                          + "qldb:ListTagsForResource",
                          + "qldb:SendCommand",
                          + "qldb:PartiQLCreateIndex",
                          + "qldb:PartiQLInsert",
                          + "qldb:PartiQLUpdate",
                          + "qldb:PartiQLSelect",
                          + "qldb:PartiQLHistoryFunction",
                          + "qldb:PartiQLRedact",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:qldb:us-west-2:042093043970:ledger/dp-dev",
                        ]
                    },
                  + {
                      + Action    = "iam:PassRole"
                      + Condition = {
                          + StringEquals = {
                              + "iam:PassedToService" = "qldb.amazonaws.com"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                    },
                  + {
                      + Action    = [
                          + "elasticmapreduce:RunJobFlow",
                        ]
                      + Condition = {
                          + StringEquals = {
                              + "aws:RequestTag/for-use-with-amazon-emr-managed-policies" = "true"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "*"
                      + Sid       = "RunJobFlowExplicitlyWithEMRManagedTag"
                    },
                  + {
                      + Action   = [
                          + "elasticmapreduce:AddInstanceFleet",
                          + "elasticmapreduce:AddInstanceGroups",
                          + "elasticmapreduce:AddJobFlowSteps",
                          + "elasticmapreduce:AddTags",
                          + "elasticmapreduce:CancelSteps",
                          + "elasticmapreduce:CreateEditor",
                          + "elasticmapreduce:CreateSecurityConfiguration",
                          + "elasticmapreduce:DeleteEditor",
                          + "elasticmapreduce:DeleteSecurityConfiguration",
                          + "elasticmapreduce:DescribeCluster",
                          + "elasticmapreduce:DescribeEditor",
                          + "elasticmapreduce:DescribeJobFlows",
                          + "elasticmapreduce:DescribeSecurityConfiguration",
                          + "elasticmapreduce:DescribeStep",
                          + "elasticmapreduce:DescribeReleaseLabel",
                          + "elasticmapreduce:GetBlockPublicAccessConfiguration",
                          + "elasticmapreduce:GetManagedScalingPolicy",
                          + "elasticmapreduce:GetAutoTerminationPolicy",
                          + "elasticmapreduce:ListBootstrapActions",
                          + "elasticmapreduce:ListClusters",
                          + "elasticmapreduce:ListEditors",
                          + "elasticmapreduce:ListInstanceFleets",
                          + "elasticmapreduce:ListInstanceGroups",
                          + "elasticmapreduce:ListInstances",
                          + "elasticmapreduce:ListSecurityConfigurations",
                          + "elasticmapreduce:ListSteps",
                          + "elasticmapreduce:ModifyCluster",
                          + "elasticmapreduce:ModifyInstanceFleet",
                          + "elasticmapreduce:ModifyInstanceGroups",
                          + "elasticmapreduce:OpenEditorInConsole",
                          + "elasticmapreduce:PutAutoScalingPolicy",
                          + "elasticmapreduce:PutBlockPublicAccessConfiguration",
                          + "elasticmapreduce:PutManagedScalingPolicy",
                          + "elasticmapreduce:RemoveAutoScalingPolicy",
                          + "elasticmapreduce:RemoveManagedScalingPolicy",
                          + "elasticmapreduce:RemoveTags",
                          + "elasticmapreduce:SetTerminationProtection",
                          + "elasticmapreduce:StartEditor",
                          + "elasticmapreduce:StopEditor",
                          + "elasticmapreduce:TerminateJobFlows",
                          + "elasticmapreduce:ViewEventsFromAllClustersInConsole",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                      + Sid      = "ElasticMapReduceActions"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role       = "airflow-dp-dev-airflow"
    }

  # module.iam_assumable_role_admin.aws_iam_role_policy_attachment.custom[2] will be created
  + resource "aws_iam_role_policy_attachment" "custom" {
      + id         = (known after apply)
      + policy_arn = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "s3:ListAllMyBuckets"
                      + Effect   = "Deny"
                      + Resource = [
                          + "arn:aws:s3:::ep-raw-zone",
                          + "arn:aws:s3:::ep-raw-zone/*",
                        ]
                    },
                  + {
                      + Action   = [
                          + "s3:PutObject*",
                          + "s3:DeleteObject*",
                        ]
                      + Effect   = "Allow"
                      + Resource = [
                          + "arn:aws:s3:::ep-raw-zone",
                          + "arn:aws:s3:::ep-raw-zone/*",
                        ]
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + role       = "airflow-dp-dev-airflow"
    }

Plan: 4 to add, 2 to change, 0 to destroy.
```
