### PR TITLE
Bugfix over airflow deafult policy

### DIFF
--- a/terraform-modules/aws/airflow/README.md
+++ b/terraform-modules/aws/airflow/README.md
@@ -60,3 +60,39 @@ No requirements.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | n/a |
 | <a name="output_webserver_url"></a> [webserver\_url](#output\_webserver\_url) | n/a |
+
+
+## Rough edges
+In default section we have a statement policy as the following
+```
+{
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:GenerateDataKey*",
+                "kms:Encrypt"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "kms:ViaService": [
+                        "sqs.${aws_region}.amazonaws.com",
+                        "s3.${aws_region}.amazonaws.com"
+                    ]
+                }
+            }
+        }
+```
+We didn't want to leave this as 
+```
+"Resource": "*",
+``` 
+We were working hard to find out why this only works with asterisk, and in the end chat gtp helped me with the answer since there is little documentation.
+finally Chat GPT was able to help 
+
+### chat gpt said:
+if you are using the default aws/airflow (which is our case in airflow with default policy) KMS key, you do not need to include a specific policy for KMS in your 
+IAM role. The necessary permissions to use this key are already granted by the service to your Amazon MWAA environment.
+Since you are using the default aws/airflow KMS key, you cannot specify its ARN directly in the policy. You can set the "Resource" field to "*" to allow access to all 
+KMS keys in your account

--- a/terraform-modules/aws/airflow/default_iam_policy.json
+++ b/terraform-modules/aws/airflow/default_iam_policy.json
@@ -76,6 +76,24 @@
                 "sqs:SendMessage"
             ],
             "Resource": "arn:aws:sqs:${aws_region}:*:airflow-celery-*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:GenerateDataKey*",
+                "kms:Encrypt"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "kms:ViaService": [
+                        "sqs.${aws_region}.amazonaws.com",
+                        "s3.${aws_region}.amazonaws.com"
+                    ]
+                }
+            }
         }
     ]
 }

--- a/terraform-modules/aws/airflow/default_iam_policy.json
+++ b/terraform-modules/aws/airflow/default_iam_policy.json
@@ -38,13 +38,14 @@
                 "logs:GetQueryResults"
             ],
             "Resource": [
-                "arn:aws:logs:${aws_region}:${aws_account_id}:log-group:airflow-${airflow_name}-*"
+                "arn:aws:logs:${aws_region}:${aws_account_id}:log-group:airflow-${airflow_name}-*:*"
             ]
         },
         {
             "Effect": "Allow",
             "Action": [
-                "logs:DescribeLogGroups"
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
             ],
             "Resource": [
                 "*"
@@ -75,24 +76,6 @@
                 "sqs:SendMessage"
             ],
             "Resource": "arn:aws:sqs:${aws_region}:*:airflow-celery-*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-                "kms:GenerateDataKey*",
-                "kms:Encrypt"
-            ],
-            "Resource": "arn:aws:kms:${aws_region}:${aws_account_id}:key/*",
-            "Condition": {
-                "StringLike": {
-                    "kms:ViaService": [
-                        "sqs.${aws_region}.amazonaws.com",
-                        "s3.${aws_region}.amazonaws.com"
-                    ]
-                }
-            }
         }
     ]
 }


### PR DESCRIPTION
- We have been some issues in airflow 
- This fix in the policy help us to overcome

![image](https://user-images.githubusercontent.com/19688747/234432243-8aca5867-4a1c-43ae-bc72-3d593c858c14.png)

```
*** Reading remote log from Cloudwatch log_group: airflow-dp-dev-airflow-Task log_stream: dag_id=elevon_data_kafka_ingestion_test/run_id=manual__2023-04-25T00_53_37.904648+00_00/task_id=elevon_data_kafka_ingestion_test/attempt=1.log.
Could not read remote logs from log_group: airflow-dp-dev-airflow-Task log_stream: dag_id=elevon_data_kafka_ingestion_test/run_id=manual__2023-04-25T00_53_37.904648+00_00/task_id=elevon_data_kafka_ingestion_test/attempt=1.log.
```

# Evidence from dev side
![image](https://user-images.githubusercontent.com/19688747/234433002-7c3b7f7c-3505-4e61-80d0-19ab3167235b.png)
