### PR TITLE
patch helm_generic -set,set_sensitive,postrender

### DIFF
--- a/terraform-modules/aws/helm/helm_generic/main.tf
+++ b/terraform-modules/aws/helm/helm_generic/main.tf
@@ -27,11 +27,8 @@ resource "helm_release" "helm_chart" {
   disable_openapi_validation = var.disable_openapi_validation
   wait                       = var.wait
   wait_for_jobs              = var.wait_for_jobs
-  set                        = var.set
-  set_sensitive              = var.set_sensitive
   dependency_update          = var.dependency_update
   replace                    = var.replace
-  postrender                 = var.postrender
   pass_credentials           = var.pass_credentials
   lint                       = var.lint
 

--- a/terraform-modules/aws/helm/helm_generic/variables.tf
+++ b/terraform-modules/aws/helm/helm_generic/variables.tf
@@ -134,24 +134,12 @@ variable "wait_for_jobs" {
   default = false
 }
 
-variable "set" {
-  default = null
-}
-
-variable "set_sensitive" {
-  default = null
-}
-
 variable "dependency_update" {
   default = false
 }
 
 variable "replace" {
   default = false
-}
-
-variable "postrender" {
-  default = null
 }
 
 variable "pass_credentials" {


### PR DESCRIPTION
[Latest commit](df092b633b61d364b8fc68d399fe972a5722f299) introduced the following behavior when using the module without supplied set, set_sensitive, or postrender inputs. 

PR would remove these as arguments until default implementation can be revisited

```
 ╷
│ Error: Unsupported argument
│ 
│   on main.tf line 30, in resource "helm_release" "helm_chart":
│   30:   set                        = var.set
│ 
│ An argument named "set" is not expected here. Did you mean to define a
│ block of type "set"?
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 31, in resource "helm_release" "helm_chart":
│   31:   set_sensitive              = var.set_sensitive
│ 
│ An argument named "set_sensitive" is not expected here. Did you mean to
│ define a block of type "set_sensitive"?
╵
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 34, in resource "helm_release" "helm_chart":
│   34:   postrender                 = var.postrender
│ 
│ An argument named "postrender" is not expected here. Did you mean to define
│ a block of type "postrender"?
╵
```

