### PR TITLE
Airflow variables configuration

### DIFF
--- a/terraform-modules/aws/airflow/README.md
+++ b/terraform-modules/aws/airflow/README.md
@@ -33,6 +33,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_airflow_configuration_options"></a> [airflow\_configuration\_options](#input\_airflow\_configuration\_options) | (Optional) The airflow\_configuration\_options parameter specifies airflow override options. Check the Official documentation for all possible configuration options. | `map(string)` | `null` | no |
 | <a name="input_airflow_name"></a> [airflow\_name](#input\_airflow\_name) | Airflow name | `string` | `"airflow"` | no |
 | <a name="input_airflow_version"></a> [airflow\_version](#input\_airflow\_version) | (Optional) Airflow version of your environment, will be set by default to the latest version that MWAA supports. | `string` | `null` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region | `string` | `"us-east-1"` | no |
@@ -42,6 +43,7 @@ No requirements.
 | <a name="input_iam_extra_policies"></a> [iam\_extra\_policies](#input\_iam\_extra\_policies) | List of additional policies to create and attach to the IAM role | <pre>list(object({<br>    name_prefix = string<br>    policy_json = string<br>  }))</pre> | `[]` | no |
 | <a name="input_max_workers"></a> [max\_workers](#input\_max\_workers) | (Optional) The maximum number of workers that can be automatically scaled up. Value need to be between 1 and 25. Will be 10 by default. | `number` | `10` | no |
 | <a name="input_min_workers"></a> [min\_workers](#input\_min\_workers) | (Optional) The minimum number of workers that you want to run in your environment. Will be 1 by default. | `number` | `1` | no |
+| <a name="input_requirements_s3_path"></a> [requirements\_s3\_path](#input\_requirements\_s3\_path) | The S3 path for the MWAA requirements file. | `string` | `""` | no |
 | <a name="input_scheduler_log_level"></a> [scheduler\_log\_level](#input\_scheduler\_log\_level) | The log level: INFO \| WARNING \| ERROR \| CRITICAL | `string` | `"INFO"` | no |
 | <a name="input_sg_extra_ids"></a> [sg\_extra\_ids](#input\_sg\_extra\_ids) | List of additional sg to create and attach to Airflow | `list(string)` | `[]` | no |
 | <a name="input_source_bucket_arn"></a> [source\_bucket\_arn](#input\_source\_bucket\_arn) | The Dag's S3 bucket arn: arn:aws:s3:::bucketname | `string` | `"s3://foo"` | no |
@@ -60,7 +62,6 @@ No requirements.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | n/a |
 | <a name="output_webserver_url"></a> [webserver\_url](#output\_webserver\_url) | n/a |
-
 
 ## Rough edges
 In default section we have a statement policy as the following

--- a/terraform-modules/aws/airflow/main.tf
+++ b/terraform-modules/aws/airflow/main.tf
@@ -46,7 +46,7 @@ resource "aws_mwaa_environment" "this" {
   execution_role_arn = module.iam_assumable_role_admin.iam_role_arn
   webserver_access_mode = var.webserver_access_mode
   requirements_s3_path  = var.requirements_s3_path
-
+  airflow_configuration_options = var.airflow_configuration_options
   logging_configuration {
     dag_processing_logs {
       enabled   = true

--- a/terraform-modules/aws/airflow/main.tf
+++ b/terraform-modules/aws/airflow/main.tf
@@ -47,6 +47,7 @@ resource "aws_mwaa_environment" "this" {
   webserver_access_mode = var.webserver_access_mode
   requirements_s3_path  = var.requirements_s3_path
   airflow_configuration_options = var.airflow_configuration_options
+  
   logging_configuration {
     dag_processing_logs {
       enabled   = true

--- a/terraform-modules/aws/airflow/variables.tf
+++ b/terraform-modules/aws/airflow/variables.tf
@@ -136,7 +136,7 @@ variable "requirements_s3_path" {
 }
 
 variable "airflow_configuration_options" {
-  description = "(Optional) The airflow_configuration_options parameter specifies airflow override options. Check the Official documentation for all possible configuration options."
-  type        = map(string)
+  description = "The Airflow override options"
+  type        = any
   default     = null
 }

--- a/terraform-modules/aws/airflow/variables.tf
+++ b/terraform-modules/aws/airflow/variables.tf
@@ -134,3 +134,9 @@ variable "requirements_s3_path" {
   type        = string
   default     = ""
 }
+
+variable "airflow_configuration_options" {
+  description = "(Optional) The airflow_configuration_options parameter specifies airflow override options. Check the Official documentation for all possible configuration options."
+  type        = map(string)
+  default     = null
+}

--- a/terraform-modules/aws/airflow/variables.tf
+++ b/terraform-modules/aws/airflow/variables.tf
@@ -135,6 +135,8 @@ variable "requirements_s3_path" {
   default     = ""
 }
 
+#You can looking for variables in the following link:
+#https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-env-variables.html
 variable "airflow_configuration_options" {
   description = "The Airflow override options"
   type        = any


### PR DESCRIPTION
# What 
- Apache Airflow configuration options can be attached to your Amazon Managed Workflows for Apache Airflow environment as environment variables
- Our airflow module didn't has this input variable
- Now is available to use

# Evidence of proof
```
 # aws_mwaa_environment.this will be updated in-place
  ~ resource "aws_mwaa_environment" "this" {
      ~ airflow_configuration_options   = (sensitive value)
        id                              = "dp-dev-airflow"
        name                            = "dp-dev-airflow"
        tags                            = {
            "ops_env"              = "dp-dev"
            "ops_managed_by"       = "terraform"
            "ops_owners"           = "devops"
            "ops_source_repo"      = "gruntwork-infrastructure-live"
            "ops_source_repo_path" = "dp-dev/us-west-2/dp-dev/dataplatform/0300-airflow"
        }
        # (19 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }
```

![Screenshot 2023-05-22 at 17 19 36](https://github.com/ManagedKube/kubernetes-ops/assets/19688747/4c81e846-4896-4364-8eae-b75025f02050)

- Code where I am using this branch?
https://github.com/exact-payments/gruntwork-infrastructure-live/pull/1703/files#diff-e4143fcd8122afe514798c50b3da9921016ca80f396b4e1e4743c4c667ffce12R140-R146