### PR TITLE
Terraform for EC2 Tagging

### DIFF
--- a/terraform-modules/aws/ec2-tag/README.md
+++ b/terraform-modules/aws/ec2-tag/README.md
@@ -1,3 +1,9 @@
+## EC2 Tagging
+- It collects information about running instances in the AWS (Amazon Web Services) cloud.
+- It retrieves the identity of the AWS account that is executing the code.
+- It creates a local variable called "instance_tags" that contains information about the instances and their associated tags.
+- It applies the AWS EC2 tag to each instance based on the collected information.
+
 ## Requirements
 
 No requirements.

--- a/terraform-modules/aws/ec2-tag/README.md
+++ b/terraform-modules/aws/ec2-tag/README.md
@@ -16,7 +16,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_ec2_tag.tag_existing_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
+| [aws_ec2_tag.tag_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_instances.existing_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instances) | data source |
 
@@ -24,7 +24,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_tags"></a> [account\_tags](#input\_account\_tags) | Tags for each AWS account | `map(map(string))` | `{}` | no |
+| <a name="input_account_tags"></a> [account\_tags](#input\_account\_tags) | Tags for each AWS account.<br><br>This variable allows you to provide tags for different AWS accounts using a map structure. Each AWS account is identified by its unique account ID, and you can specify multiple tags for each account using key-value pairs.<br><br>Example Usage:<br><br>inputs:<br>  {<br>    "account\_id\_1" = {<br>      "key1" = "value1"<br>      "key2" = "value2"<br>      "key3" = "value3"<br>      "key4" = "value4"<br>    }<br>    "account\_id\_1" = {<br>      "key1" = "value1"<br>      "key2" = "value2"<br>      "key3" = "value3"<br>      "key4" = "value4"<br>    }<br>    ... (Add more AWS account tags here) ...<br>  } | `map(map(string))` | `{}` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"us-west-2"` | no |
 
 ## Outputs

--- a/terraform-modules/aws/ec2-tag/README.md
+++ b/terraform-modules/aws/ec2-tag/README.md
@@ -1,0 +1,34 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_tag.tag_existing_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_instances.existing_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/instances) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_tags"></a> [account\_tags](#input\_account\_tags) | Tags for each AWS account | `map(map(string))` | `{}` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region | `string` | `"us-west-2"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_tags"></a> [instance\_tags](#output\_instance\_tags) | n/a |

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -2,6 +2,8 @@ data "aws_instances" "existing_instances" {
   instance_state_names = ["running"]
 }
 
+data "aws_caller_identity" "current" {}
+
 locals {
   instance_tags = flatten([
     for instance in data.aws_instances.running_instances.instances : [

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -6,9 +6,9 @@ data "aws_caller_identity" "current" {}
 
 locals {
   instance_tags = flatten([
-    for instance in data.aws_instances.existing_instances.ids : [
+    for ec2_id in data.aws_instances.existing_instances.ids : [
       for key, value in var.account_tags[data.aws_caller_identity.current.account_id] : {
-        resource_id = instance.id
+        resource_id = ec2_id
         key         = key
         value       = value
       }

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -7,7 +7,7 @@ data "aws_caller_identity" "current" {}
 locals {
   instance_tags = flatten([
     for instance in data.aws_instances.existing_instances.ids : [
-      for key, value in instance.tags : {
+      for key, value in var.account_tags[data.aws_caller_identity.current.account_id] : {
         resource_id = instance.id
         key         = key
         value       = value

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -13,7 +13,7 @@ locals {
   }
 }
 
-resource "aws_instance_tag" "tag_existing_instances" {
+resource "aws_ec2_tag" "tag_existing_instances" {
   count       = length(data.aws_instances.existing_instances.ids)
   instance_id = data.aws_instances.existing_instances.ids[count.index]
 

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -8,18 +8,5 @@ resource "aws_ec2_tag" "tag_existing_instances" {
   for_each    = toset(data.aws_instances.existing_instances.ids)
   resource_id = each.key
 
-  dynamic "tag" {
-    for_each = [
-      for tag_key, tag_value in var.account_tags[data.aws_caller_identity.current.account_id] : {
-        key   = tag_key
-        value = tag_value
-      }
-      if tag_key in ["Env", "Platform", "Domain_2", "Domain_3"]
-    ]
-
-    content {
-      key   = tag.key
-      value = tag.value
-    }
-  }
 }
+

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "current" {}
 
 locals {
   instance_tags = flatten([
-    for instance in data.aws_instances.running_instances.instances : [
+    for instance in data.aws_instances.existing_instances.ids : [
       for key, value in instance.tags : {
         resource_id = instance.id
         key         = key

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -4,16 +4,13 @@ data "aws_instances" "existing_instances" {
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_ec2_tag" "tag_existing_instances" {
-  for_each = toset(data.aws_instances.existing_instances.ids)
+resource "aws_ec2_tag" "tag_instances" {
+  for_each = data.aws_instances.running_instances.instances
 
-  resource_id = each.key
+  resource_id = each.value.id
 
-  tags = merge(
-    {
-      "Platform" = contains(keys(local.tags), "Platform") ? local.tags["Platform"] : "null"
-      "Env"     = contains(keys(local.tags), "Env")    ? local.tags["Env"]    : "null"
-    },
-    local.tags
-  )
+  tags = {
+    for key, value in each.value.tags : key => value
+  }
+  propagate_at_launch = false
 }

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -4,9 +4,18 @@ data "aws_instances" "existing_instances" {
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_ec2_tag" "tag_existing_instances" {
-  for_each    = toset(data.aws_instances.existing_instances.ids)
-  resource_id = each.key
-
+locals {
+  tags = {
+    for instance_id, instance_tags in data.aws_instances.existing_instances.ids : instance_id => {
+      for variable in ["Env", "Platform", "Domain_2", "Domain_3"] : variable => var.account_tags[data.aws_caller_identity.current.account_id][variable]
+      if var.account_tags[data.aws_caller_identity.current.account_id][variable] != null
+    }
+  }
 }
 
+resource "aws_instance_tag" "tag_existing_instances" {
+  count       = length(data.aws_instances.existing_instances.ids)
+  instance_id = data.aws_instances.existing_instances.ids[count.index]
+
+  tags = local.tags[data.aws_instances.existing_instances.ids[count.index]]
+}

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -9,7 +9,13 @@ resource "aws_ec2_tag" "tag_existing_instances" {
   resource_id = each.key
 
   dynamic "tag" {
-    for_each = var.account_tags[data.aws_caller_identity.current.account_id]
+    for_each = [
+      for tag_key, tag_value in var.account_tags[data.aws_caller_identity.current.account_id] : {
+        key   = tag_key
+        value = tag_value
+      }
+      if tag_key in ["Env", "Platform", "Domain_2", "Domain_3"]
+    ]
 
     content {
       key   = tag.key

--- a/terraform-modules/aws/ec2-tag/main.tf
+++ b/terraform-modules/aws/ec2-tag/main.tf
@@ -1,0 +1,19 @@
+data "aws_instances" "existing_instances" {
+  instance_state_names = ["running"]
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_ec2_tag" "tag_existing_instances" {
+  for_each    = toset(data.aws_instances.existing_instances.ids)
+  resource_id = each.key
+
+  dynamic "tag" {
+    for_each = var.account_tags[data.aws_caller_identity.current.account_id]
+
+    content {
+      key   = tag.key
+      value = tag.value
+    }
+  }
+}

--- a/terraform-modules/aws/ec2-tag/output.tf
+++ b/terraform-modules/aws/ec2-tag/output.tf
@@ -1,0 +1,3 @@
+output "instance_tags" {
+  value = var.account_tags[data.aws_caller_identity.current.account_id]
+}

--- a/terraform-modules/aws/ec2-tag/variables.tf
+++ b/terraform-modules/aws/ec2-tag/variables.tf
@@ -1,0 +1,11 @@
+variable "account_tags" {
+  description = "Tags for each AWS account"
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-west-2"
+}

--- a/terraform-modules/aws/ec2-tag/variables.tf
+++ b/terraform-modules/aws/ec2-tag/variables.tf
@@ -1,5 +1,28 @@
 variable "account_tags" {
-  description = "Tags for each AWS account"
+  description = <<-EOF
+    Tags for each AWS account.
+    
+    This variable allows you to provide tags for different AWS accounts using a map structure. Each AWS account is identified by its unique account ID, and you can specify multiple tags for each account using key-value pairs.
+
+    Example Usage:
+
+    inputs:
+      {
+        "account_id_1" = {
+          "key1" = "value1"
+          "key2" = "value2"
+          "key3" = "value3"
+          "key4" = "value4"
+        }
+        "account_id_1" = {
+          "key1" = "value1"
+          "key2" = "value2"
+          "key3" = "value3"
+          "key4" = "value4"
+        }
+        ... (Add more AWS account tags here) ...
+      }
+  EOF
   type        = map(map(string))
   default     = {}
 }


### PR DESCRIPTION
## EC2 Tagging
- It collects information about running instances in the AWS (Amazon Web Services) cloud.
- It retrieves the identity of the AWS account that is executing the code.
- It creates a local variable called "instance_tags" that contains information about the instances and their associated tags.
- It applies the AWS EC2 tag to each instance based on the collected information.