### PR TITLE
GuardDutty Thread Detector

### DIFF
--- a/terraform-modules/aws/guarddutty/threat-detection/README.md
+++ b/terraform-modules/aws/guarddutty/threat-detection/README.md
@@ -27,8 +27,8 @@ The code you provided is written in HashiCorp Configuration Language (HCL) and i
         This resource creates an email subscription for the SNS topic.
         The topic_arn attribute specifies the ARN of the SNS topic to subscribe to.
         The protocol attribute specifies the protocol to use for the subscription, which is email in this case.
-        The endpoint attribute provides a list of email addresses that will receive notifications when events are published to the SNS topic. In this example, the email addresses are "dramesh@exactpay.com," "jsmillie@exactpay.com," and "pkarunakaran@exactpay.com."
-
+        The endpoint attribute provides a list of email addresses that will receive notifications when events are published to the SNS topic. 
+        
 ## Requirements
 
 No requirements.

--- a/terraform-modules/aws/guarddutty/threat-detection/README.md
+++ b/terraform-modules/aws/guarddutty/threat-detection/README.md
@@ -1,0 +1,72 @@
+## AWS GuardDuty Thread Detector
+
+The code you provided is written in HashiCorp Configuration Language (HCL) and it is used to define and provision resources on Amazon Web Services (AWS). Let's break it down into simpler terms:
+
+    aws_guardduty_detector resource:
+        This resource enables the AWS GuardDuty service, which is a threat detection service that continuously monitors AWS accounts for suspicious activities and malicious behavior.
+        When enable is set to true, it activates GuardDuty for the AWS account.
+
+    aws_sns_topic resource:
+        This resource defines an Amazon Simple Notification Service (SNS) topic.
+        SNS is a pub/sub messaging service that allows you to send messages to multiple subscribers or endpoints.
+        The name attribute specifies the name of the SNS topic, which is obtained from the sns_topic_name variable.
+
+    aws_cloudwatch_event_rule resource:
+        This resource creates a CloudWatch Events rule.
+        CloudWatch Events is a service that enables you to respond to changes in AWS resources or services.
+        The rule defined here is named "GuardDutyFindingRule" and is used for GuardDuty findings.
+        The event_pattern attribute specifies the JSON pattern for events that should trigger this rule. In this case, it matches events from the "aws.guardduty" source and with the "GuardDuty Finding" detail type.
+
+    aws_cloudwatch_event_target resource:
+        This resource defines a target for the CloudWatch Events rule.
+        The rule attribute specifies the name of the CloudWatch Events rule to associate the target with.
+        The target_id attribute provides an identifier for this target.
+        The arn attribute specifies the Amazon Resource Name (ARN) of the SNS topic created earlier. This means that when the CloudWatch Events rule is triggered, it will send events to this SNS topic.
+
+    aws_sns_topic_subscription resource:
+        This resource creates an email subscription for the SNS topic.
+        The topic_arn attribute specifies the ARN of the SNS topic to subscribe to.
+        The protocol attribute specifies the protocol to use for the subscription, which is email in this case.
+        The endpoint attribute provides a list of email addresses that will receive notifications when events are published to the SNS topic. In this example, the email addresses are "dramesh@exactpay.com," "jsmillie@exactpay.com," and "pkarunakaran@exactpay.com."
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.guardduty_event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.sns_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_guardduty_detector.guardduty_detector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) | resource |
+| [aws_sns_topic.guardduty_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_subscription.email_subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_event_rule_description"></a> [event\_rule\_description](#input\_event\_rule\_description) | Description of the CloudWatch Events rule | `string` | `"Event rule for GuardDuty findings"` | no |
+| <a name="input_event_rule_name"></a> [event\_rule\_name](#input\_event\_rule\_name) | Name of the CloudWatch Events rule | `string` | `"GuardDutyFindingRule"` | no |
+| <a name="input_event_target_id"></a> [event\_target\_id](#input\_event\_target\_id) | Identifier for the CloudWatch Events target | `string` | `"GuardDutySNSTarget"` | no |
+| <a name="input_guardduty_enabled"></a> [guardduty\_enabled](#input\_guardduty\_enabled) | Enable or disable AWS GuardDuty | `bool` | `true` | no |
+| <a name="input_sns_topic_name"></a> [sns\_topic\_name](#input\_sns\_topic\_name) | Name of the SNS topic | `string` | `"guardduty-topic"` | no |
+| <a name="input_subscription_endpoints"></a> [subscription\_endpoints](#input\_subscription\_endpoints) | List of email addresses to receive notifications | `list(string)` | <pre>[<br>  "xxxx@domain.com"<br>]</pre> | no |
+| <a name="input_subscription_protocol"></a> [subscription\_protocol](#input\_subscription\_protocol) | Protocol for the SNS topic subscription | `string` | `"email"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_sns_topic_arn"></a> [sns\_topic\_arn](#output\_sns\_topic\_arn) | ARN of the created SNS topic |

--- a/terraform-modules/aws/guarddutty/threat-detection/main.tf
+++ b/terraform-modules/aws/guarddutty/threat-detection/main.tf
@@ -1,0 +1,30 @@
+resource "aws_guardduty_detector" "guardduty_detector" {
+  enable = var.guardduty_enabled
+}
+
+resource "aws_sns_topic" "guardduty_topic" {
+  name = var.sns_topic_name
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_event_rule" {
+  name        = var.event_rule_name
+  description = var.event_rule_description
+
+  event_pattern = jsonencode({
+    "source"      : ["aws.guardduty"],
+    "detail-type" : ["GuardDuty Finding"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "sns_target" {
+  rule      = aws_cloudwatch_event_rule.guardduty_event_rule.name
+  target_id = var.event_target_id
+
+  arn = aws_sns_topic.guardduty_topic.arn
+}
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  topic_arn = aws_sns_topic.guardduty_topic.arn
+  protocol  = var.subscription_protocol
+  endpoint  = var.subscription_endpoints
+}

--- a/terraform-modules/aws/guarddutty/threat-detection/outputs.tf
+++ b/terraform-modules/aws/guarddutty/threat-detection/outputs.tf
@@ -1,0 +1,4 @@
+output "sns_topic_arn" {
+  description = "ARN of the created SNS topic"
+  value       = aws_sns_topic.guardduty_topic.arn
+}

--- a/terraform-modules/aws/guarddutty/threat-detection/variables.tf
+++ b/terraform-modules/aws/guarddutty/threat-detection/variables.tf
@@ -1,0 +1,43 @@
+variable "guardduty_enabled" {
+  description = "Enable or disable AWS GuardDuty"
+  type        = bool
+  default     = true
+}
+
+variable "sns_topic_name" {
+  description = "Name of the SNS topic"
+  type        = string
+  default     = "guardduty-topic"
+}
+
+variable "event_rule_name" {
+  description = "Name of the CloudWatch Events rule"
+  type        = string
+  default     = "GuardDutyFindingRule"
+}
+
+variable "event_rule_description" {
+  description = "Description of the CloudWatch Events rule"
+  type        = string
+  default     = "Event rule for GuardDuty findings"
+}
+
+variable "event_target_id" {
+  description = "Identifier for the CloudWatch Events target"
+  type        = string
+  default     = "GuardDutySNSTarget"
+}
+
+variable "subscription_protocol" {
+  description = "Protocol for the SNS topic subscription"
+  type        = string
+  default     = "email"
+}
+
+variable "subscription_endpoints" {
+  description = "List of email addresses to receive notifications"
+  type        = list(string)
+  default     = [
+    "xxxx@domain.com"
+  ]
+}


### PR DESCRIPTION
# What
Overall, the code sets up GuardDuty for threat detection, creates an SNS topic to receive notifications, defines a CloudWatch Events rule to trigger on GuardDuty findings, associates the SNS topic as the target for the rule, and subscribes email addresses to receive notifications when GuardDuty events occur.