### PR TITLE
aws-parameterization-2

### DIFF
--- a/terraform-modules/aws/cluster-autoscaler/main.tf
+++ b/terraform-modules/aws/cluster-autoscaler/main.tf
@@ -1,6 +1,6 @@
 module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = var.iam_assumable_role_admin_version
+  version                       = "3.6.0"
   create_role                   = true
   role_name                     = "cluster-autoscaler-${var.cluster_name}"
   provider_url                  = replace(var.eks_cluster_oidc_issuer_url, "https://", "")

--- a/terraform-modules/aws/cluster-autoscaler/variables.tf
+++ b/terraform-modules/aws/cluster-autoscaler/variables.tf
@@ -40,9 +40,3 @@ variable "cluster-autoscaler_helm_version" {
   default     = "9.24.0"
   description = "cluster-autoscaler helm chart version.  https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler"
 }
-
-variable "iam_assumable_role_admin_version" {
-  type        = string
-  default     = "3.6.0"
-  description = "iam_assumable_role_admin module version"
-}

--- a/terraform-modules/aws/helm/kube-prometheus-stack/main.tf
+++ b/terraform-modules/aws/helm/kube-prometheus-stack/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "helm_chart" {
 module "iam_assumable_role_grafana" {
   count                         = var.enable_iam_assumable_role_grafana ? 1 : 0
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = var.iam_assumable_role_grafana_version
+  version                       = "3.6.0"
   create_role                   = true
   role_name                     = local.k8s_service_account_name
   provider_url                  = replace(var.eks_cluster_oidc_issuer_url, "https://", "")

--- a/terraform-modules/aws/helm/kube-prometheus-stack/variables.tf
+++ b/terraform-modules/aws/helm/kube-prometheus-stack/variables.tf
@@ -87,9 +87,3 @@ variable "aws_policy_grafana" {
 EOF
   description = "The AWS policy for the Grafana AWS role.  The default is a read only role to all Cloudwatch logs."
 }
-
-variable "iam_assumable_role_grafana_version" {
-  type        = string
-  default     = "3.6.0"
-  description = "iam_assumable_role_grafana module version"
-}


### PR DESCRIPTION
Fixing incorrect usage of the `version` var.  It can NOT be parameterized.