### PR TITLE
Msk feature 2

### DIFF
--- a/terraform-modules/aws/msk_1.0.9/main.tf
+++ b/terraform-modules/aws/msk_1.0.9/main.tf
@@ -144,6 +144,8 @@ module "msk" {
   multi_vpc_connectivity_iam_enabled  = var.multi_vpc_connectivity_iam_enabled
   properties                          = var.properties
   allowed_security_group_ids          = var.allowed_security_group_ids
+  associated_security_group_ids       = var.associated_security_group_ids
+  create_security_group               = var.create_security_group
   depends_on = [
     aws_cloudwatch_log_group.msk_cloudwatch_log_group,
     aws_s3_bucket.this,

--- a/terraform-modules/aws/msk_1.0.9/variables.tf
+++ b/terraform-modules/aws/msk_1.0.9/variables.tf
@@ -117,6 +117,21 @@ variable "allowed_security_group_ids" {
   description = "The security_group_id_list output from the security_groups module"
 }
 
+variable "create_security_group" {
+  type        = bool
+  description = "Set `true` to create and configure a new security group. If false, `associated_security_group_ids` must be provided."
+  default     = true
+}
+
+variable "associated_security_group_ids" {
+  type        = list(string)
+  description = <<-EOT
+    A list of IDs of Security Groups to associate the created resource with, in addition to the created security group.
+    These security groups will not be modified and, if `create_security_group` is `false`, must have rules providing the desired access.
+    EOT
+  default     = []
+}
+
 variable "client_tls_auth_enabled" {
   type        = bool
   description = "Set true to enable the Client TLS Authentication"


### PR DESCRIPTION
- Adding 2 of new env vars to control if you want to create security group by own.

<img width="1453" alt="Screenshot 2023-12-15 at 22 08 12" src="https://github.com/ManagedKube/kubernetes-ops/assets/19688747/5636125d-30bc-48f7-8eda-9c511d6b8c0c">

<img width="429" alt="Screenshot 2023-12-15 at 22 08 23" src="https://github.com/ManagedKube/kubernetes-ops/assets/19688747/2c0cf0b1-1110-4241-964b-4050d35c95ef">

Where We are using this ?
https://github.com/exact-payments/gruntwork-infrastructure-live/pull/2007/files#diff-3e84ea31afb4f168a3ab0b0bf716e9e6109f1f31491a3c6b37fec378db7dc901R19