### PR TITLE
Chore/Issue#449 - AWS terraform provider version updated for VPC module and GH workflow update

### DIFF
--- a/.github/workflows/terraform-pipeline-staging.yaml
+++ b/.github/workflows/terraform-pipeline-staging.yaml
@@ -15,6 +15,10 @@ on:
     paths:
     - 'terraform-environments/aws/staging/**'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   ## This generates a matrix of changed directory to run Terraform on
   generate_matrix:
@@ -27,7 +31,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/terraform-environments/aws/dev/10-vpc/main.tf
+++ b/terraform-environments/aws/dev/10-vpc/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.37.0"
+      version = ">= 3.67.0"
     }
   }
 

--- a/terraform-environments/aws/dev/10-vpc/main.tf
+++ b/terraform-environments/aws/dev/10-vpc/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 3.37.0"
     }
   }
 

--- a/terraform-environments/aws/dev/10-vpc/main.tf
+++ b/terraform-environments/aws/dev/10-vpc/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.67.0"
+      version = ">= 4.67.0"
     }
   }
 

--- a/terraform-environments/aws/staging/10-vpc/main.tf
+++ b/terraform-environments/aws/staging/10-vpc/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.37.0"
+      version = ">= 5.31.0"
     }
   }
 

--- a/terraform-modules/aws/vpc/main.tf
+++ b/terraform-modules/aws/vpc/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.7.0"
+  version = "5.4.0"
 
   name = var.environment_name
   cidr = var.vpc_cidr
@@ -38,14 +38,14 @@ module "vpc" {
     "kubernetes.io/role/internal-elb"           = "1"
     "ops_purpose"                               = "Overloaded for k8s worker usage"
   }
-  
+
   tags = var.tags
 
   #Default Security Group Management (Default: secure)
-  manage_default_security_group   = var.manage_default_security_group
-  default_security_group_name     = var.default_security_group_name
-  default_security_group_egress   = var.default_security_group_egress
-  default_security_group_ingress  = var.default_security_group_ingress
-  default_security_group_tags     = var.default_security_group_tags
-  
+  manage_default_security_group  = var.manage_default_security_group
+  default_security_group_name    = var.default_security_group_name
+  default_security_group_egress  = var.default_security_group_egress
+  default_security_group_ingress = var.default_security_group_ingress
+  default_security_group_tags    = var.default_security_group_tags
+
 }


### PR DESCRIPTION
### PR Description

This resolves issue https://github.com/ManagedKube/kubernetes-ops/issues/449

#### Changes:

1. AWS terraform provider version updated for VPC module
    
      With the retirement of EC2-Classic the `enable_classiclink` and` enable_classiclink_dns_support` attributes have been removed https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0  hence while trying to use the vpc module with the current configured provider version  I get the following error:
      
      ```bash
      An argument named "enable_classiclink" is not expected here.
      ```
      
      Solution: Upgrade the terraform-aws-modules/vpc/aws version to `5.4.0` (latest version atm) along with the latest version of the aws terraform provider which atm is `5.31.0`

1.  The `terraform-pipeline-staging.yaml` was updated so it can properly add the comments to the opened PR
